### PR TITLE
Adapt documentation after renaming/moving repository

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
-name: Python package
+name: Python tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-# dcm-spec-tools
+# dicom-validator
 
-[![PyPI version](https://badge.fury.io/py/dcm-spec-tools.svg)](https://pypi.org/project/dcm-spec-tools) ![Python package](https://github.com/mrbean-bremen/dcm-spec-tools/workflows/Python%20package/badge.svg) [![Python version](https://img.shields.io/pypi/pyversions/dcm-spec-tools.svg)](https://pypi.org/project/dcm-spec-tools)
+[![PyPI version](https://badge.fury.io/py/dicom-validator.svg)](https://pypi.org/project/dicom-validator) ![Python package](https://github.com/pydicom/dicom-validator/workflows/Python%20package/badge.svg) [![Python version](https://img.shields.io/pypi/pyversions/dicom-validator.svg)](https://pypi.org/project/dicom-validator)
 
-*dcm-spec-tools* is planned to be a collection of simple pure python command line tools which get the input from 
-the DICOM standard in docbook format as provided by [ACR NEMA](http://medical.nema.org/).
+*dicom-validator* was planned to be a collection of simple pure python command line tools which get the input from 
+the DICOM standard in docbook format as provided by [ACR NEMA](http://medical.nema.org/). 
+As the only relevant tool is the validator tool, and no further tools are planned, the package has now been renamed
+from the original name *dcm-spec-tools*, and moved to the pydicom organization.
 
 Currently available tools:  
 * `validate_iods` checks DICOM files for correct attributes for the given SOP class.  
-* `dump_dcm_info` outputs the DICOM tag IDs and values of a given DICOM file.
+* `dump_dcm_info` outputs the DICOM tag IDs and values of a given DICOM file 
+  (used as a simple demonstration for access to the DICOM standard).
 
 Note that this is still in an early stage of development.
 
@@ -18,7 +21,7 @@ Installation
 ------------
 The latest version is available on pypi and can be installed via
 ```
-pip install dcm-spec-tools
+pip install dicom-validator
 ```
 
 Usage
@@ -107,7 +110,7 @@ or due to a bug
 
 The output for a single file may look like this:
 ```
-(py3_test) c:\dev\GitHub\dcm-spec-tools>validate_iods "c:\dev\DICOM Data\SR\test.dcm"
+(py3_test) c:\dev\GitHub\dicom-validator>validate_iods "c:\dev\DICOM Data\SR\test.dcm"
 
 Processing DICOM file "c:\dev\DICOM Data\SR\test.dcm"
 SOP class is "1.2.840.10008.5.1.4.1.1.88.33" (Comprehensive SR IOD)

--- a/dcm_spec_tools/spec_reader/tests/test_edition_reader.py
+++ b/dcm_spec_tools/spec_reader/tests/test_edition_reader.py
@@ -26,7 +26,7 @@ class EditionReaderTest(pyfakefs.fake_filesystem_unittest.TestCase):
     def setUp(self):
         super(EditionReaderTest, self).setUp()
         self.setUpPyfakefs()
-        self.base_path = os.path.join('user', 'dcm-spec-tools')
+        self.base_path = os.path.join('user', 'dicom-validator')
         self.fs.create_dir(self.base_path)
         logging.disable(logging.CRITICAL)
 

--- a/dcm_spec_tools/validate_iods.py
+++ b/dcm_spec_tools/validate_iods.py
@@ -30,7 +30,7 @@ def main():
                         nargs='+')
     parser.add_argument('--standard-path', '-src',
                         help='Base path with the DICOM specs in docbook and json format',
-                        default=os.path.join(os.path.expanduser("~"), 'dcm-spec-tools'))
+                        default=os.path.join(os.path.expanduser("~"), 'dicom-validator'))
     parser.add_argument('--revision', '-r',
                         help='Standard revision (e.g. "2014c"), year of '
                              'revision, "current" or "local" (latest '

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(BASE_PATH, 'README.md')) as f:
 
 
 setup(
-    name="dcm-spec-tools",
+    name="dicom-validator",
     packages=find_packages(),
     include_package_data=True,
     version=__version__,
@@ -21,7 +21,7 @@ setup(
     description="Python DICOM tools using input from DICOM specs in docbook format",
     author="mrbean-bremen",
     author_email="hansemrbean@googlemail.com",
-    url="http://github.com/mrbean-bremen/dcm-spec-tools",
+    url="http://github.com/pydicom/dicom-validator",
     keywords="dicom python",
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
- mrbean-bremen/dcm-spec-tools is now pydicom/dicom-validator