### PR TITLE
Validate entire dataset

### DIFF
--- a/dicom_validator/spec_reader/edition_reader.py
+++ b/dicom_validator/spec_reader/edition_reader.py
@@ -50,7 +50,7 @@ class EditionReader(object):
     def __init__(self, path):
         self.path = path
         self.logger = logging.getLogger()
-        if not self.logger.handlers:
+        if not self.logger.hasHandlers():
             self.logger.addHandler(logging.StreamHandler(sys.stdout))
 
     def update_edition(self):

--- a/dicom_validator/spec_reader/part3_reader.py
+++ b/dicom_validator/spec_reader/part3_reader.py
@@ -27,7 +27,7 @@ class Part3Reader(SpecReader):
         self._module_descriptions = {}
         self._current_refs = []
         self.logger = logging.getLogger()
-        if not self.logger.handlers:
+        if not self.logger.hasHandlers():
             self.logger.addHandler(logging.StreamHandler(sys.stdout))
         if dict_info is not None:
             self._condition_parser = ConditionParser(self._dict_info)

--- a/dicom_validator/spec_reader/part3_reader.py
+++ b/dicom_validator/spec_reader/part3_reader.py
@@ -246,7 +246,9 @@ class Part3Reader(SpecReader):
                 # silently ignore error in older specs
                 pass
         elif level < current_level:
-            current_descriptions.pop()
+            # Pop off (delete) the last level_delta items.
+            level_delta = current_level - level
+            del current_descriptions[-level_delta:]
         return tag_name, level
 
     def _get_iod_modules(self, iod_node):

--- a/dicom_validator/spec_reader/tests/test_spec_reader.py
+++ b/dicom_validator/spec_reader/tests/test_spec_reader.py
@@ -35,5 +35,6 @@ class ReadSpecTest(pyfakefs.fake_filesystem_unittest.TestCase):
         self.assertEqual('1.2.840.10008.5.1.4.1.1.88.72',
                          SpecReader.cleaned_value(orig_value))
 
-        if __name__ == '__main__':
-            unittest.main()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dicom_validator/validate_iods.py
+++ b/dicom_validator/validate_iods.py
@@ -12,7 +12,7 @@ def validate(args, base_path):
     iod_info = EditionReader.load_iod_info(json_path)
     module_info = EditionReader.load_module_info(json_path)
     log_level = logging.DEBUG if args.verbose else logging.INFO
-    validator = DicomFileValidator(iod_info, module_info, dict_info, log_level)
+    validator = DicomFileValidator(iod_info, module_info, dict_info, log_level, args.force_read)
     error_nr = 0
     for dicom_path in args.dicomfiles:
         error_nr += sum(len(error) for error in
@@ -37,6 +37,9 @@ def main(args=None):
                              'revision, "current" or "local" (latest '
                              'locally installed)',
                         default='current')
+    parser.add_argument('--force-read', action='store_true',
+                        help='Force-read DICOM files without header',
+                        default=False)
     parser.add_argument('--verbose', '-v', action='store_true',
                         help='Outputs diagnostic information')
     args = parser.parse_args(args)

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -10,7 +10,7 @@ from dicom_validator.validator.iod_validator import IODValidator
 
 class DicomFileValidator(object):
     def __init__(self, iod_info, module_info, dict_info=None,
-                 log_level=logging.INFO):
+                 log_level=logging.INFO, force_read=False):
         self._module_info = module_info
         self._iod_info = iod_info
         self._dict_info = dict_info
@@ -18,6 +18,7 @@ class DicomFileValidator(object):
         self.logger.level = log_level
         if not self.logger.handlers:
             self.logger.addHandler(logging.StreamHandler(sys.stdout))
+        self._force_read = force_read
 
     def validate(self, path):
         errors = {}
@@ -41,7 +42,7 @@ class DicomFileValidator(object):
     def validate_file(self, file_path):
         self.logger.info('\nProcessing DICOM file "%s"', file_path)
         try:
-            data_set = dcmread(file_path, defer_size=1024)
+            data_set = dcmread(file_path, defer_size=1024, force=self._force_read)
         except InvalidDicomError:
             self.logger.error(f'Invalid DICOM file: {file_path}')
             return {file_path: {'fatal': 'Invalid DICOM file'}}

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -43,6 +43,7 @@ class DicomFileValidator(object):
         try:
             data_set = dcmread(file_path, defer_size=1024)
         except InvalidDicomError:
+            self.logger.error(f'Invalid DICOM file: {file_path}')
             return {file_path: {'fatal': 'Invalid DICOM file'}}
         return {
             file_path: IODValidator(data_set, self._iod_info,

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -16,7 +16,7 @@ class DicomFileValidator(object):
         self._dict_info = dict_info
         self.logger = logging.getLogger()
         self.logger.level = log_level
-        if not self.logger.handlers:
+        if not self.logger.hasHandlers():
             self.logger.addHandler(logging.StreamHandler(sys.stdout))
         self._force_read = force_read
 

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -310,7 +310,7 @@ class IODValidator(object):
         tag_name = tag_name_from_id(tag_id, self._dict_info)
         msg = f'Tag {tag_name} is {error_kind}'
         if len(extra_message) != 0:
-            msg += extra_message
+            msg = f'{msg} {extra_message}'
         return msg
     
     def _conditon_message(self, condition_dict):

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -19,6 +19,7 @@ class IODValidator(object):
         self._dict_info = dict_info
         self.errors = {}
         self.logger = logging.getLogger('validator')
+        self.logger.propagate = 0
         self.logger.level = log_level
         if not self.logger.handlers:
             self.logger.addHandler(logging.StreamHandler(sys.stdout))

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -31,9 +31,8 @@ class IODValidator(object):
         self._dict_info = dict_info
         self.errors = {}
         self.logger = logging.getLogger('validator')
-        self.logger.propagate = 0
         self.logger.level = log_level
-        if not self.logger.handlers:
+        if not self.logger.hasHandlers():
             self.logger.addHandler(logging.StreamHandler(sys.stdout))
 
     def validate(self):

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -1,9 +1,18 @@
 import json
 import logging
 import sys
+import pydicom
+
 
 from dicom_validator.spec_reader.condition import Condition
 from dicom_validator.tag_tools import tag_name_from_id
+
+
+class DatasetStackItem:
+    def __init__(self, dataset, name):
+        self.dataset = dataset
+        self.name = name
+        self.unexpected_tags = { int(d.tag) for d in dataset }
 
 
 class InvalidParameterError(Exception):
@@ -14,6 +23,9 @@ class IODValidator(object):
     def __init__(self, dataset, iod_info, module_info, dict_info=None,
                  log_level=logging.INFO):
         self._dataset = dataset
+        self._dataset_stack = [
+            DatasetStackItem(self._dataset, None)
+        ]
         self._iod_info = iod_info
         self._module_info = module_info
         self._dict_info = dict_info
@@ -52,14 +64,20 @@ class IODValidator(object):
 
     def _validate_sop_class(self, sop_class_uid):
         iod_info = self._iod_info[sop_class_uid]
+
         self.logger.info('SOP class is "%s" (%s)', sop_class_uid,
                          iod_info['title'])
         self.logger.debug('Checking modules for SOP Class')
         self.logger.debug('------------------------------')
+
         for module_name, module in iod_info['modules'].items():
+            self._dataset_stack[-1].name = module_name
             errors = self._validate_module(module, module_name)
             if errors:
                 self.errors[module_name] = errors
+
+        if len(self._dataset_stack[-1].unexpected_tags) != 0:
+            self.errors["Root"] = self._create_unexpected_tag_errors()
 
     def _validate_module(self, module, module_name):
         errors = {}
@@ -85,14 +103,10 @@ class IODValidator(object):
                 tag_id = self._tag_id(tag_id_string)
                 if tag_id in self._dataset:
                     message = self._incorrect_tag_message(tag_id,
-                                                          'not allowed', None)
+                                                          'not allowed')
                     errors.setdefault(message, []).append(tag_id_string)
         else:
-            for tag_id_string, attribute in module_info.items():
-                result = self._validate_attribute(self._tag_id(tag_id_string),
-                                                  attribute)
-                if result is not None:
-                    errors.setdefault(result, []).append(tag_id_string)
+            errors.update(self._validate_attributes(module_info, False))
         return errors
 
     def _log_module_required(self, module_name, required, allowed,
@@ -107,9 +121,15 @@ class IODValidator(object):
                 msg += condition.to_string(self._dict_info)
         self.logger.debug(msg)
 
-    def _incorrect_tag_message(self, tag_id, error_kind, condition_dict):
-        msg = 'Tag {} is {}'.format(tag_name_from_id(tag_id, self._dict_info),
-                                    error_kind)
+    def _tag_context(self):
+        context = ""
+        for item in self._dataset_stack:
+            context += f'{item.name} > '
+        return context
+
+    def _incorrect_tag_message(self, tag_id, error_kind, condition_dict = None):
+        msg = 'In {}\nTag {} is {}'.format(
+            self._tag_context(), tag_name_from_id(tag_id, self._dict_info), error_kind)
         if condition_dict:
             condition = Condition.read_condition(condition_dict)
             if condition.type != 'U':
@@ -117,12 +137,48 @@ class IODValidator(object):
                 msg += condition.to_string(self._dict_info)
         return msg
 
+    def _validate_attributes(self, attributes, report_unexpected_tags):
+        errors = {}
+
+        for tag_id_string, attribute in attributes.items():
+            tag_id = self._tag_id(tag_id_string)
+
+            result = self._validate_attribute(tag_id, attribute)
+            if result is not None:
+                errors.setdefault(result, []).append(tag_id_string)
+            
+            self._dataset_stack[-1].unexpected_tags.discard(tag_id)
+
+            if "items" in attribute:
+                data_elem = self._dataset_stack[-1].dataset.get_item(tag_id)
+                if data_elem is None:
+                    continue
+                if data_elem.VR != "SQ":
+                    raise RuntimeError(f"Not a sequence: {data_elem}")
+                for i, sq_item_dataset in enumerate(data_elem.value):
+                    self._dataset_stack.append(
+                        DatasetStackItem(sq_item_dataset, tag_id_string))
+                    errors.update(self._validate_attributes(attribute["items"], True))
+                    self._dataset_stack.pop()
+
+        if report_unexpected_tags:
+            errors.update(self._create_unexpected_tag_errors())
+
+        return errors
+
+    def _create_unexpected_tag_errors(self):
+        errors = {}
+        for tag_id in self._dataset_stack[-1].unexpected_tags:
+            message = self._incorrect_tag_message(tag_id, 'unexpected')
+            errors.setdefault(message, []).append(self._tag_id_string(tag_id))
+        return errors
+
     def _validate_attribute(self, tag_id, attribute):
         attribute_type = attribute['type']
         # ignore image data and larger tags for now - we don't read them
         if tag_id >= 0x7FE00010:
             return
-        has_tag = tag_id in self._dataset
+        has_tag = tag_id in self._dataset_stack[-1].dataset
         value_required = attribute_type in ('1', '1C')
         condition_dict = None
         if attribute_type in ('1', '2'):
@@ -130,9 +186,7 @@ class IODValidator(object):
         elif attribute_type in ('1C', '2C'):
             if 'cond' in attribute:
                 condition_dict = attribute['cond']
-                tag_required, tag_allowed = (
-                    self._object_is_required_or_allowed(condition_dict)
-                )
+                tag_required, tag_allowed = self._object_is_required_or_allowed(condition_dict)
             else:
                 tag_required, tag_allowed = False, True
         else:
@@ -141,7 +195,7 @@ class IODValidator(object):
         if not has_tag and tag_required:
             error_kind = 'missing'
         elif (tag_required and value_required and
-              self._dataset[tag_id].value is None):
+              self._dataset_stack[-1].dataset[tag_id].value is None):
             error_kind = 'empty'
         elif has_tag and not tag_allowed:
             error_kind = 'not allowed'
@@ -178,11 +232,11 @@ class IODValidator(object):
         tag_value = None
         operator = condition['op']
         if operator == '+':
-            return tag_id in self._dataset
+            return self._tag_exists(tag_id)
         elif operator == '-':
-            return tag_id not in self._dataset
-        elif tag_id in self._dataset:
-            tag = self._dataset[tag_id]
+            return not self._tag_exists(tag_id)
+        elif self._tag_exists(tag_id):
+            tag = self._lookup_tag(tag_id)
             index = condition['index']
             if index > 0:
                 if index <= tag.VM:
@@ -200,12 +254,20 @@ class IODValidator(object):
 
     def _has_module(self, module_info):
         for tag_id_string, attribute in module_info.items():
-            if attribute['type'] != '3':
-                tag_id = self._tag_id(tag_id_string)
-                # crude check - attribute could be also in another module
-                if tag_id in self._dataset:
-                    return True
+            tag_id = self._tag_id(tag_id_string)
+            # crude check - the attribute may belong to another module
+            if tag_id in self._dataset:
+                return True
         return False
+
+    def _lookup_tag(self, tag_id):
+        for stack_item in reversed(self._dataset_stack):
+            if tag_id in stack_item.dataset:
+                return stack_item.dataset[tag_id]
+        return None
+
+    def _tag_exists(self, tag_id):
+        return self._lookup_tag(tag_id) is not None
 
     @staticmethod
     def _tag_id(tag_id_string):
@@ -216,7 +278,19 @@ class IODValidator(object):
         return (int(group, 16) << 16) + int(element, 16)
 
     @staticmethod
+    def _tag_id_string(tag_id):
+        tag = pydicom.tag.Tag(tag_id)
+        return str(tag).replace(' ', '')
+
+    @staticmethod
     def _tag_matches(tag_value, operator, values):
+        # TODO: These fix-ups should be done in ConditionParser:
+        if "non-zero" in values:
+            operator = '!='
+            values = [ '0' ]
+        if "zero" in values:
+            values = [ '0' ]
+
         values = [type(tag_value)(value) for value in values]
         if operator == '=':
             return tag_value in values
@@ -234,11 +308,20 @@ class IODValidator(object):
         return self._expanded_module_info(self._module_info[module_ref])
 
     def _expanded_module_info(self, module_info):
-        if 'include' in module_info:
-            for ref in module_info['include']:
-                module_info.update(self._get_module_info(ref))
-            del module_info['include']
-        if 'items' in module_info:
-            module_info['items'] = self._expanded_module_info(
-                module_info['items'])
-        return module_info
+        expanded_mod_info = {}
+        for k, v in module_info.items():
+            if k == 'include':
+                for ref in module_info['include']:
+                    expanded_mod_info.update(self._get_module_info(ref))
+            elif isinstance(v, dict) :
+                expanded_mod_info[k] = self._expanded_module_info(v)
+            else:
+                expanded_mod_info[k] = v
+        return expanded_mod_info
+
+    # For debugging
+    def _dump_dict_as_json(self, name, d):
+        print(f'{{')
+        print(f'"{name}": ')
+        print(json.dumps(d, indent=2))
+        print(f'}}')

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -308,7 +308,9 @@ class IODValidator(object):
 
     def _incorrect_tag_message(self, tag_id, error_kind, extra_message = ""):
         tag_name = tag_name_from_id(tag_id, self._dict_info)
-        msg = f'Tag {tag_name} is {error_kind} {extra_message}'
+        msg = f'Tag {tag_name} is {error_kind}'
+        if len(extra_message) != 0:
+            msg += extra_message
         return msg
     
     def _conditon_message(self, condition_dict):


### PR DESCRIPTION
This PR:
- Fixes broken module_info.json: The indented attributes were not handled correctly. Different indent levels got mixed together.
- Fixes duplicate logger output (`logger.hasHandlers()` vs `logger.handlers`)
- Adds --force-read command line option to validate_iods.py (for validating DCM files without DICOM header)
- Traverses the entire DICOM dataset, not just the module's top-level.
- Checks for "unexpected" attributes: Some attributes are either non-standard or they exist in the wrong place in the dataset. This check warns/errors about these cases.
