### PR TITLE
Rename test classes to be found by pytest

### DIFF
--- a/dicom_validator/tests/spec_reader/test_condition.py
+++ b/dicom_validator/tests/spec_reader/test_condition.py
@@ -1,7 +1,7 @@
 from dicom_validator.spec_reader.condition import Condition
 
 
-class ConditionReadTest:
+class TestConditionRead:
     def check_condition(
         self,
         cond_dict,
@@ -14,7 +14,7 @@ class ConditionReadTest:
         nr_or_cond=0,
     ):
         condition = Condition.read_condition(cond_dict)
-        assert cond_type == condition.type
+        assert condition.type == cond_type
         self.check_sub_condition(
             condition, index, op, tag, values, nr_and_cond, nr_or_cond
         )
@@ -24,12 +24,12 @@ class ConditionReadTest:
     def check_sub_condition(
         condition, index=0, op=None, tag=None, values=None, nr_and_cond=0, nr_or_cond=0
     ):
-        assert index == condition.index
-        assert op == condition.operator
-        assert tag == condition.tag
-        assert values or [] == condition.values
-        assert nr_and_cond == len(condition.and_conditions)
-        assert nr_or_cond == len(condition.or_conditions)
+        assert condition.index == index
+        assert condition.operator == op
+        assert condition.tag == tag
+        assert condition.values == (values or [])
+        assert len(condition.and_conditions) == nr_and_cond
+        assert len(condition.or_conditions) == nr_or_cond
 
     def test_read_type_only(self):
         self.check_condition({"type": "U"}, "U")

--- a/dicom_validator/tests/spec_reader/test_condition_parser.py
+++ b/dicom_validator/tests/spec_reader/test_condition_parser.py
@@ -8,25 +8,25 @@ def parser(dict_info):
     yield ConditionParser(dict_info)
 
 
-class InvalidConditionParserTest:
+class TestInvalidConditionParser:
     def test_ignore_invalid_condition(self, parser):
         result = parser.parse("")
         assert result.tag is None
-        assert "U" == result.type
+        assert result.type == "U"
 
     def test_ignore_uncheckable_tag_condition(self, parser):
         result = parser.parse(
             "Required if Numeric Value (0040,A30A) has insufficient "
             "precision to represent the value as a string."
         )
-        assert "U" == result.type
+        assert result.type == "U"
         assert result.tag is None
 
     def test_ignore_condition_without_tag(self, parser):
         result = parser.parse(
             "Required if present and consistent " "in the contributing SOP Instances. "
         )
-        assert "U" == result.type
+        assert result.type == "U"
 
     def test_ignore_condition_without_value(self, parser):
         # regression test for #15
@@ -34,82 +34,82 @@ class InvalidConditionParserTest:
             "required if Selector Attribute (0072,0026) is nested in "
             "one or more Sequences or is absent."
         )
-        assert "U" == result.type
+        assert result.type == "U"
 
 
-class SimpleConditionParserTest:
+class TestSimpleConditionParser:
     def test_not_present(self, parser):
         result = parser.parse(
             "Required if VOI LUT Sequence (0028,3010) is not present."
         )
-        assert "MN" == result.type
-        assert "(0028,3010)" == result.tag
-        assert "-" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0028,3010)"
+        assert result.operator == "-"
+        assert result.values == []
 
     def test_operator_in_tag(self, parser):
         result = parser.parse(
             "Required if Fractional Channel Display Scale " "(003A,0247) is not present"
         )
-        assert "MN" == result.type
-        assert "(003A,0247)" == result.tag
-        assert "-" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(003A,0247)"
+        assert result.operator == "-"
+        assert result.values == []
 
     def test_is_present(self, parser):
         result = parser.parse(
             "Required if Bounding Box Top Left Hand Corner " "(0070,0010) is present."
         )
-        assert "MN" == result.type
-        assert "(0070,0010)" == result.tag
-        assert "+" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0070,0010)"
+        assert result.operator == "+"
+        assert result.values == []
 
     def test_is_present_with_value(self, parser):
         result = parser.parse(
             "Required if Responsible Person is present and has a value."
         )
-        assert "MN" == result.type
-        assert "(0010,2297)" == result.tag
-        assert "++" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0010,2297)"
+        assert result.operator == "++"
+        assert result.values == []
 
     def test_is_present_tag_name_with_digit(self, parser):
         result = parser.parse("Required if 3D Mating Point (0068,64C0) is present.")
-        assert "MN" == result.type
-        assert "(0068,64C0)" == result.tag
-        assert "+" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0068,64C0)"
+        assert result.operator == "+"
+        assert result.values == []
 
     def test_not_sent(self, parser):
         result = parser.parse(
             "Required if Anatomic Region Modifier Sequence " "(0008,2220) is not sent. "
         )
-        assert "MN" == result.type
-        assert "(0008,2220)" == result.tag
-        assert "-" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,2220)"
+        assert result.operator == "-"
+        assert result.values == []
 
     def test_shall_be_condition_with_absent_tag(self, parser):
         result = parser.parse(
             "Some Stuff. Shall be present if Clinical Trial Subject Reading ID"
             " (0012,0042) is absent. May be present otherwise."
         )
-        assert "MU" == result.type
-        assert "(0012,0042)" == result.tag
-        assert 0 == result.index
-        assert "-" == result.operator
-        assert [] == result.values
+        assert result.type == "MU"
+        assert result.tag == "(0012,0042)"
+        assert result.index == 0
+        assert result.operator == "-"
+        assert result.values == []
 
     def test_required_only_if(self, parser):
         result = parser.parse(
             "Required only if Referenced Dose Reference Number (300C,0051) "
             "is not present. It shall not be present otherwise."
         )
-        assert "MN" == result.type
-        assert "(300C,0051)" == result.tag
-        assert "-" == result.operator
-        assert [] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(300C,0051)"
+        assert result.operator == "-"
+        assert result.values == []
 
     def test_values_failed_parsing(self, parser):
         """Regression test for #20
@@ -118,134 +118,134 @@ class SimpleConditionParserTest:
             "Required if Constraint Violation Significance (0082,0036) "
             "is only significant under certain conditions."
         )
-        assert "U" == result.type
+        assert result.type == "U"
 
 
-class ValueConditionParserTest:
+class TestValueConditionParser:
     def test_equality_tag(self, parser):
         result = parser.parse("C - Required if Modality (0008,0060) = IVUS")
-        assert "MN" == result.type
-        assert "(0008,0060)" == result.tag
-        assert 0 == result.index
-        assert "=" == result.operator
-        assert ["IVUS"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0060)"
+        assert result.index == 0
+        assert result.operator == "="
+        assert result.values == ["IVUS"]
 
     def test_equality_tag_without_tag_id(self, parser):
         result = parser.parse("C - Required if Modality = IVUS")
-        assert "MN" == result.type
-        assert "(0008,0060)" == result.tag
-        assert 0 == result.index
-        assert "=" == result.operator
-        assert ["IVUS"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0060)"
+        assert result.index == 0
+        assert result.operator == "="
+        assert result.values == ["IVUS"]
 
     def test_multiple_values_and_index(self, parser):
         result = parser.parse(
             "C - Required if Image Type (0008,0008) Value 3 "
             "is GATED, GATED TOMO, or RECON GATED TOMO"
         )
-        assert "MN" == result.type
-        assert "(0008,0008)" == result.tag
-        assert 2 == result.index
-        assert "=" == result.operator
-        assert ["GATED", "GATED TOMO", "RECON GATED TOMO"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0008)"
+        assert result.index == 2
+        assert result.operator == "="
+        assert result.values == ["GATED", "GATED TOMO", "RECON GATED TOMO"]
 
     def test_multiple_values_with_or(self, parser):
         result = parser.parse(
             "Required if Value Type (0040,A040) is " "COMPOSITE or IMAGE or WAVEFORM."
         )
-        assert "MN" == result.type
-        assert "(0040,A040)" == result.tag
-        assert 0 == result.index
-        assert "=" == result.operator
-        assert ["COMPOSITE", "IMAGE", "WAVEFORM"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0040,A040)"
+        assert result.index == 0
+        assert result.operator == "="
+        assert result.values == ["COMPOSITE", "IMAGE", "WAVEFORM"]
 
     def test_comma_before_value(self, parser):
         result = parser.parse(
             "Required if Series Type (0054,1000), Value 2 is REPROJECTION."
         )
-        assert "MN" == result.type
-        assert "(0054,1000)" == result.tag
-        assert 1 == result.index
-        assert "=" == result.operator
-        assert ["REPROJECTION"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0054,1000)"
+        assert result.index == 1
+        assert result.operator == "="
+        assert result.values == ["REPROJECTION"]
 
     def test_may_be_present_otherwise(self, parser):
         result = parser.parse(
             "C - Required if Image Type (0008,0008) Value 1 equals ORIGINAL."
             " May be present otherwise."
         )
-        assert "MU" == result.type
-        assert "(0008,0008)" == result.tag
-        assert 0 == result.index
-        assert "=" == result.operator
-        assert ["ORIGINAL"] == result.values
+        assert result.type == "MU"
+        assert result.tag == "(0008,0008)"
+        assert result.index == 0
+        assert result.operator == "="
+        assert result.values == ["ORIGINAL"]
 
     def test_greater_operator(self, parser):
         result = parser.parse("C - Required if Number of Frames is greater than 1")
-        assert "MN" == result.type
-        assert "(0028,0008)" == result.tag
-        assert 0 == result.index
-        assert ">" == result.operator
-        assert ["1"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0028,0008)"
+        assert result.index == 0
+        assert result.operator == ">"
+        assert result.values == ["1"]
 
     def test_value_greater_than_operator(self, parser):
         result = parser.parse(
             "Required if Samples per Pixel " "(0028,0002) has a value greater than 1"
         )
-        assert "MN" == result.type
-        assert "(0028,0002)" == result.tag
-        assert 0 == result.index
-        assert ">" == result.operator
-        assert ["1"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0028,0002)"
+        assert result.index == 0
+        assert result.operator == ">"
+        assert result.values == ["1"]
 
     def test_tag_ids_as_values(self, parser):
         result = parser.parse(
             "C - Required if Frame Increment Pointer (0028,0009) "
             "is Frame Time (0018,1063) or Frame Time Vector (0018,1065)"
         )
-        assert "MN" == result.type
-        assert "(0028,0009)" == result.tag
-        assert 0 == result.index
-        assert "=" == result.operator
-        assert [
+        assert result.type == "MN"
+        assert result.tag == "(0028,0009)"
+        assert result.index == 0
+        assert result.operator == "="
+        assert result.values == [
             "Frame Time (0018,1063)",
             "Frame Time Vector (0018,1065)",
-        ] == result.values
+        ]
 
     def test_has_a_value_of(self, parser):
         result = parser.parse(
             "Required if Pixel Presentation " "(0008,9205) has a value of TRUE_COLOR."
         )
-        assert "MN" == result.type
-        assert "(0008,9205)" == result.tag
-        assert "=" == result.operator
-        assert ["TRUE_COLOR"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,9205)"
+        assert result.operator == "="
+        assert result.values == ["TRUE_COLOR"]
 
     def test_at_the_image_level_equals(self, parser):
         result = parser.parse(
             '"Required if Pixel Presentation (0008,9205) at the image level '
             "equals COLOR or MIXED."
         )
-        assert "MN" == result.type
-        assert "=" == result.operator
-        assert ["COLOR", "MIXED"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "="
+        assert result.values == ["COLOR", "MIXED"]
 
     def test_is_with_colon(self, parser):
         result = parser.parse(
             "Required if Image Type " "(0008,0008) Value 3 is: WHOLE BODY or STATIC."
         )
-        assert "MN" == result.type
-        assert "(0008,0008)" == result.tag
-        assert "=" == result.operator
-        assert 2 == result.index
-        assert ["WHOLE BODY", "STATIC"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0008)"
+        assert result.operator == "="
+        assert result.index == 2
+        assert result.values == ["WHOLE BODY", "STATIC"]
 
     def test_remove_apostrophes(self, parser):
         result = parser.parse(
             'Required if Lossy Image Compression (0028,2110) is "01".'
         )
-        assert "=" == result.operator
-        assert ["01"] == result.values
+        assert result.operator == "="
+        assert result.values == ["01"]
 
     def test_remove_apostrophes_from_uids(self, parser):
         result = parser.parse(
@@ -253,102 +253,102 @@ class ValueConditionParserTest:
             'equals "1.2.840.10008.5.1.4.1.1.12.1.1" '
             'or "1.2.840.10008.5.1.4.1.1.12.2.1". May be present otherwise.'
         )
-        assert "=" == result.operator
-        assert [
+        assert result.operator == "="
+        assert result.values == [
             "1.2.840.10008.5.1.4.1.1.12.1.1",
             "1.2.840.10008.5.1.4.1.1.12.2.1",
-        ] == result.values
+        ]
 
     def test_value_of(self, parser):
         result = parser.parse(
             "Required if the value of Context Group Extension Flag "
             '(0008,010B) is "Y".'
         )
-        assert "MN" == result.type
-        assert "=" == result.operator
-        assert ["Y"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "="
+        assert result.values == ["Y"]
 
     def test_value_more_than(self, parser):
         result = parser.parse(
             "Required if Data Point Rows " "(0028,9001) has a value of more than 1."
         )
-        assert "MN" == result.type
-        assert "(0028,9001)" == result.tag
-        assert ">" == result.operator
-        assert ["1"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0028,9001)"
+        assert result.operator == ">"
+        assert result.values == ["1"]
 
     def test_is_not_with_uid(self, parser):
         result = parser.parse(
             "Required if SOP Class UID is not "
             '"1.2.840.10008.5.1.4.1.1.4.4" (Legacy Converted).'
         )
-        assert "MN" == result.type
-        assert "(0008,0016)" == result.tag
-        assert "!=" == result.operator
-        assert ["1.2.840.10008.5.1.4.1.1.4.4"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0016)"
+        assert result.operator == "!="
+        assert result.values == ["1.2.840.10008.5.1.4.1.1.4.4"]
 
     def test_present_with_value(self, parser):
         result = parser.parse(
             "Required if Selector Attribute VR "
             "(0072,0050) is present and the value is AS."
         )
-        assert "MN" == result.type
-        assert "=" == result.operator
-        assert ["AS"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "="
+        assert result.values == ["AS"]
 
     def test_value_is_not(self, parser):
         result = parser.parse("Required if Shadow Style (0070,0244) value is not OFF.")
-        assert "MN" == result.type
-        assert "!=" == result.operator
-        assert ["OFF"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "!="
+        assert result.values == ["OFF"]
 
     def test_other_than(self, parser):
         result = parser.parse(
             "Required if Decay Correction (0054,1102) is other than NONE."
         )
-        assert "MN" == result.type
-        assert "!=" == result.operator
-        assert ["NONE"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "!="
+        assert result.values == ["NONE"]
 
     def test_not_equal_to(self, parser):
         result = parser.parse(
             "Required if Planes in Acquisition "
             "(0018,9410) is not equal to UNDEFINED."
         )
-        assert "MN" == result.type
-        assert "!=" == result.operator
-        assert ["UNDEFINED"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "!="
+        assert result.values == ["UNDEFINED"]
 
     def test_equal_to(self, parser):
         result = parser.parse(
             "Required if Blending Mode (0070,1B06) is equal to FOREGROUND."
         )
-        assert "MN" == result.type
-        assert "=" == result.operator
-        assert ["FOREGROUND"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "="
+        assert result.values == ["FOREGROUND"]
 
     def test_present_with_value_of(self, parser):
         result = parser.parse(
             "Required if Partial View " "(0028,1350) is present with a value of YES."
         )
-        assert "MN" == result.type
-        assert "=" == result.operator
-        assert ["YES"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "="
+        assert result.values == ["YES"]
 
     def test_points_to_tag(self, parser):
         result = parser.parse(
             "Required if Frame Increment Pointer (0028,0009) points to "
             "Frame Label Vector (0018,2002)."
         )
-        assert "MN" == result.type
-        assert "=>" == result.operator
-        assert ["1581058"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "=>"
+        assert result.values == ["1581058"]
 
     def test_non_zero(self, parser):
         result = parser.parse("Required if Number of Blocks (300A,00F0) is non-zero.")
-        assert "MN" == result.type
-        assert "!=" == result.operator
-        assert ["0"] == result.values
+        assert result.type == "MN"
+        assert result.operator == "!="
+        assert result.values == ["0"]
 
     def test_non_null(self, parser):
         result = parser.parse(
@@ -357,7 +357,7 @@ class ValueConditionParserTest:
         assert result.type == "MN"
         assert result.tag == "(300A,02A2)"
         assert result.operator == "++"
-        assert [] == result.values
+        assert result.values == []
 
     def test_zero_length(self, parser):
         result = parser.parse(
@@ -367,89 +367,87 @@ class ValueConditionParserTest:
         assert result.type == "MC"
         assert result.tag == "(300A,00E1)"
         assert result.operator == "="
-        assert [""] == result.values
+        assert result.values == [""]
         assert result.other_condition is not None
 
     def test_greater_than_zero(self, parser):
         result = parser.parse(
             "Required if Number of Beams (300A,0080) is greater than zero"
         )
-        assert "MN" == result.type
-        assert ">" == result.operator
-        assert ["0"] == result.values
+        assert result.type == "MN"
+        assert result.operator == ">"
+        assert result.values == ["0"]
 
     def test_is_non_zero_length(self, parser):
         result = parser.parse("Required if Material ID (300A,00E1) is non-zero length.")
-        assert "MN" == result.type
-        assert "!=" == result.operator
-        assert [""] == result.values
+        assert result.type == "MN"
+        assert result.operator == "!="
+        assert result.values == [""]
 
     def test_is_not_zero_length(self, parser):
         result = parser.parse(
             "Required if value Transfer Tube Number (300A,02A2) " "is not zero length."
         )
-        assert "MN" == result.type
-        assert "!=" == result.operator
-        assert [""] == result.values
+        assert result.type == "MN"
+        assert result.operator == "!="
+        assert result.values == [""]
 
     def test_equal_sign(self, parser):
-        result = parser.parse(
-            "Required if Pixel Component Organization == Bit aligned."
-        )
-        assert "MN" == result.type
-        assert "(0018,6044)" == result.tag
-        assert "=" == result.operator
-        assert ["Bit aligned"] == result.values
+        result = parser.parse("Required if Pixel Component Organization = Bit aligned.")
+        assert result.type == "MN"
+        assert result.tag == "(0018,6044)"
+        assert result.operator == "="
+        assert result.values == ["Bit aligned"]
 
     def test_value_has_explanation(self, parser):
         result = parser.parse(
             "Required if Conversion Type (0008,0064) is DF (Digitized Film)."
         )
-        assert "MN" == result.type
-        assert "(0008,0064)" == result.tag
-        assert "=" == result.operator
-        assert ["DF"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0064)"
+        assert result.operator == "="
+        assert result.values == ["DF"]
 
     def test_values_have_explanation(self, parser):
         result = parser.parse(
             "Required if Conversion Type (0008,0064) is SD "
             "(Scanned Document) or SI (Scanned Image)."
         )
-        assert "MN" == result.type
-        assert "(0008,0064)" == result.tag
-        assert "=" == result.operator
-        assert ["SD", "SI"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0008,0064)"
+        assert result.operator == "="
+        assert result.values == ["SD", "SI"]
 
     def test_is_with_colon_after_value(self, parser):
         result = parser.parse(
             "Required if the value of Reformatting Operation Type "
             "(0072,0510) is 3D_RENDERING:"
         )
-        assert "MN" == result.type
-        assert "(0072,0510)" == result.tag
-        assert "=" == result.operator
-        assert ["3D_RENDERING"] == result.values
+        assert result.type == "MN"
+        assert result.tag == "(0072,0510)"
+        assert result.operator == "="
+        assert result.values == ["3D_RENDERING"]
 
     def test_is_set_to(self, parser):
         result = parser.parse(
             "Required if Ophthalmic Volumetric Properties Flag (0022,1622) "
             "is set to YES. May be present otherwise."
         )
-        assert "MU" == result.type
-        assert "(0022,1622)" == result.tag
-        assert "=" == result.operator
-        assert ["YES"] == result.values
+        assert result.type == "MU"
+        assert result.tag == "(0022,1622)"
+        assert result.operator == "="
+        assert result.values == ["YES"]
 
 
-class NotMandatoryConditionParserTest:
+class TestNotMandatoryConditionParser:
     def test_default(self, parser):
         result = parser.parse(
             "Required if Image Type "
             "(0008,0008) Value 1 is ORIGINAL. May be present otherwise."
         )
-        assert "MU" == result.type
-        assert "=" == result.operator
-        assert ["ORIGINAL"] == result.values
+        assert result.type == "MU"
+        assert result.operator == "="
+        assert result.values == ["ORIGINAL"]
 
     def test_comma_instead_of_dot(self, parser):
         result = parser.parse(
@@ -457,60 +455,60 @@ class NotMandatoryConditionParserTest:
             "(003A,0248) is not present, "
             "may be present otherwise."
         )
-        assert "MU" == result.type
-        assert "-" == result.operator
+        assert result.type == "MU"
+        assert result.operator == "-"
 
     def test_missing_dot(self, parser):
         result = parser.parse(
             "Required if Image Type "
             "(0008,0008) Value 1 is ORIGINAL May be present otherwise."
         )
-        assert "MU" == result.type
-        assert "=" == result.operator
-        assert ["ORIGINAL"] == result.values
+        assert result.type == "MU"
+        assert result.operator == "="
+        assert result.values == ["ORIGINAL"]
 
 
-class CompositeConditionParserTest:
+class TestCompositeConditionParser:
     def test_and_condition(self, parser):
         result = parser.parse(
             "Required if Series Type (0054,1000), Value 1 is GATED and "
             "Beat Rejection Flag (0018,1080) is Y."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
         result1 = result.and_conditions[0]
-        assert "(0054,1000)" == result1.tag
-        assert "=" == result1.operator
-        assert ["GATED"] == result1.values
+        assert result1.tag == "(0054,1000)"
+        assert result1.operator == "="
+        assert result1.values == ["GATED"]
         result2 = result.and_conditions[1]
-        assert "(0018,1080)" == result2.tag
-        assert "=" == result2.operator
-        assert ["Y"] == result2.values
+        assert result2.tag == "(0018,1080)"
+        assert result2.operator == "="
+        assert result2.values == ["Y"]
 
     def test_ignore_unverifyable_and_condition(self, parser):
         result = parser.parse(
             "Required if Delivery Type (300A,00CE) is CONTINUATION and "
             "one or more channels of any Application Setup are omitted."
         )
-        assert "MN" == result.type
-        assert 0 == len(result.and_conditions)
-        assert "=" == result.operator
-        assert ["CONTINUATION"] == result.values
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 0
+        assert result.operator == "="
+        assert result.values == ["CONTINUATION"]
 
     def test_and_without_value(self, parser):
         result = parser.parse(
             "Required if Recorded Channel Sequence (3008,0130) is sent and "
             "Brachy Treatment Type (300A,0202) is not MANUAL or PDR."
         )
-        assert "MN", result.type
-        assert 2, len(result.and_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
         result1 = result.and_conditions[0]
-        assert "(3008,0130)" == result1.tag
-        assert "+" == result1.operator
+        assert result1.tag == "(3008,0130)"
+        assert result1.operator == "+"
         result2 = result.and_conditions[1]
-        assert "(300A,0202)" == result2.tag
-        assert "!=" == result2.operator
-        assert ["MANUAL", "PDR"] == result2.values
+        assert result2.tag == "(300A,0202)"
+        assert result2.operator == "!="
+        assert result2.values == ["MANUAL", "PDR"]
 
     def test_and_with_multiple_values(self, parser):
         result = parser.parse(
@@ -518,12 +516,12 @@ class CompositeConditionParserTest:
             "and Respiratory Motion Compensation Technique "
             "(0018,9170) equals other than NONE."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
-        assert "=" == result.and_conditions[0].operator
-        assert ["ORIGINAL", "MIXED"] == result.and_conditions[0].values
-        assert "!=" == result.and_conditions[1].operator
-        assert ["NONE"] == result.and_conditions[1].values
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
+        assert result.and_conditions[0].operator == "="
+        assert result.and_conditions[0].values == ["ORIGINAL", "MIXED"]
+        assert result.and_conditions[1].operator == "!="
+        assert result.and_conditions[1].values == ["NONE"]
 
     def test_either_or_tag_presence(self, parser):
         result = parser.parse(
@@ -531,13 +529,13 @@ class CompositeConditionParserTest:
             "(0010,0033) or Patient's Alternative Death Date in Calendar "
             "(0010,0034) is present."
         )
-        assert "MN" == result.type
+        assert result.type == "MN"
         result1 = result.or_conditions[0]
-        assert "(0010,0033)" == result1.tag
-        assert "+" == result1.operator
+        assert result1.tag == "(0010,0033)"
+        assert result1.operator == "+"
         result2 = result.or_conditions[1]
-        assert "(0010,0034)" == result2.tag
-        assert "+" == result2.operator
+        assert result2.tag == "(0010,0034)"
+        assert result2.operator == "+"
 
     def test_multiple_tag_absence(self, parser):
         result = parser.parse(
@@ -546,10 +544,10 @@ class CompositeConditionParserTest:
             "(0040,E025) and XDS Retrieval Sequence "
             "(0040,E024) are not present. May be present otherwise."
         )
-        assert "MU" == result.type
-        assert 4 == len(result.and_conditions)
+        assert result.type == "MU"
+        assert len(result.and_conditions) == 4
         for result_part in result.and_conditions:
-            assert "-" == result_part.operator
+            assert result_part.operator == "-"
 
     def test_multiple_tag_absence_with_comma(self, parser):
         result = parser.parse(
@@ -558,32 +556,32 @@ class CompositeConditionParserTest:
             "and WADO-RS Retrieval Sequence (0040,E025) "
             "and XDS Retrieval Sequence (0040,E024) are not present."
         )
-        assert "MN" == result.type
-        assert 4 == len(result.and_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 4
         for result_part in result.and_conditions:
-            assert "-" == result_part.operator
+            assert result_part.operator == "-"
 
     def test_multiple_tag_presence(self, parser):
         result = parser.parse(
             "Required if Selector Attribute (0072,0026) and "
             "Filter-by Operator (0072,0406) are present."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
         for result_part in result.and_conditions:
-            assert "+" == result_part.operator
+            assert result_part.operator == "+"
 
     def test_mixed_and_or_tag_presence(self, parser):
         result = parser.parse(
             "Required if Selector Attribute (0072,0026) or Filter-by Category "
             "(0072,0402), and Filter-by Operator (0072,0406) are present."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
-        assert 2 == len(result.and_conditions[0].or_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
+        assert len(result.and_conditions[0].or_conditions) == 2
         for result_part in result.and_conditions[0].or_conditions:
-            assert "+" == result_part.operator
-        assert "+" == result.and_conditions[1].operator
+            assert result_part.operator == "+"
+        assert result.and_conditions[1].operator == "+"
 
     def test_multi_tag_in_second_condition(self, parser):
         result = parser.parse(
@@ -591,22 +589,22 @@ class CompositeConditionParserTest:
             "and if Referenced Time Offsets (0040,A138) and "
             "Referenced DateTime (0040,A13A) are not present."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
-        assert 2 == len(result.and_conditions[1].and_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
+        assert len(result.and_conditions[1].and_conditions) == 2
         for result_part in result.and_conditions[1].and_conditions:
-            assert "-" == result_part.operator
-        assert "+" == result.and_conditions[0].operator
+            assert result_part.operator == "-"
+        assert result.and_conditions[0].operator == "+"
 
     def test_is_present_with_multiple_tags(self, parser):
         result = parser.parse(
             "Required if Bounding Box Top Left Hand Corner (0070,0010) "
             "or Bounding Box Bottom Right Hand Corner (0070,0011) is present."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.or_conditions)
+        assert result.type == "MN"
+        assert len(result.or_conditions) == 2
         for result_part in result.or_conditions:
-            assert "+" == result_part.operator
+            assert result_part.operator == "+"
 
     def test_multiple_tags_with_value(self, parser):
         result = parser.parse(
@@ -615,13 +613,13 @@ class CompositeConditionParserTest:
             "Image Box Tile Horizontal Dimension (0072,0306) or "
             "Image Box Tile Vertical Dimension (0072,0308) is greater than 1."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
-        assert 2 == len(result.and_conditions[1].or_conditions)
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
+        assert len(result.and_conditions[1].or_conditions) == 2
         for result_part in result.and_conditions[1].or_conditions:
-            assert ">" == result_part.operator
+            assert result_part.operator == ">"
             assert result_part.values
-            assert "1" == result_part.values[0]
+            assert result_part.values[0] == "1"
 
     def test_ispresent_with_value(self, parser):
         result = parser.parse(
@@ -629,19 +627,19 @@ class CompositeConditionParserTest:
             "has a value of YES and De-identification Method Code Sequence "
             "(0012,0064) is not present."
         )
-        assert "MN" == result.type
-        assert 2 == len(result.and_conditions)
-        assert "=" == result.and_conditions[0].operator
-        assert "YES" == result.and_conditions[0].values[0]
-        assert "-" == result.and_conditions[1].operator
+        assert result.type == "MN"
+        assert len(result.and_conditions) == 2
+        assert result.and_conditions[0].operator == "="
+        assert result.and_conditions[0].values[0] == "YES"
+        assert result.and_conditions[1].operator == "-"
 
     def check_or_condition(self, result):
-        assert "MN" == result.type
-        assert 2 == len(result.or_conditions)
-        assert "=" == result.or_conditions[0].operator
-        assert "PALETTE COLOR" == result.or_conditions[0].values[0]
-        assert "=" == result.or_conditions[1].operator
-        assert ["COLOR", "MIXED"] == result.or_conditions[1].values
+        assert result.type == "MN"
+        assert len(result.or_conditions) == 2
+        assert result.or_conditions[0].operator == "="
+        assert result.or_conditions[0].values[0] == "PALETTE COLOR"
+        assert result.or_conditions[1].operator == "="
+        assert result.or_conditions[1].values == ["COLOR", "MIXED"]
 
     def test_or_condition_with_space(self, parser):
         result = parser.parse(
@@ -660,7 +658,7 @@ class CompositeConditionParserTest:
         self.check_or_condition(result)
 
 
-class ComplicatedConditionParserTest:
+class TestComplicatedConditionParser:
     def disabled_test_ispresent_with_value(self, parser):
         result = parser.parse(
             'Required if Graphic Data (0070,0022) is "closed", '
@@ -668,14 +666,14 @@ class ComplicatedConditionParserTest:
             "or Graphic Type (0070,0023) is POLYLINE or INTERPOLATED "
             "and the first data point is the same as the last data point."
         )
-        assert "MN" == result.type
-        assert 3 == len(result.or_conditions)
-        assert "=" == result.or_conditions[0].operator
-        assert ["closed"] == result.or_conditions[0].values
-        assert "=" == result.or_conditions[1].operator
-        assert ["CIRCLE", "ELLIPSE"] == result.or_conditions[1].values
-        assert "=" == result.or_conditions[2].operator
-        assert ["POLYLINE", "INTERPOLATED"] == result.or_conditions[2].values
+        assert result.type == "MN"
+        assert len(result.or_conditions) == 3
+        assert result.or_conditions[0].operator == "="
+        assert result.or_conditions[0].values == ["closed"]
+        assert result.or_conditions[1].operator == "="
+        assert result.or_conditions[1].values == ["CIRCLE", "ELLIPSE"]
+        assert result.or_conditions[2].operator == "="
+        assert result.or_conditions[2].values == ["POLYLINE", "INTERPOLATED"]
 
     def test_other_condition1(self, parser):
         result = parser.parse(
@@ -685,17 +683,17 @@ class ComplicatedConditionParserTest:
             "(0068,6590) is present and "
             "HPGL Document Sequence (0068,62C0) is present."
         )
-        assert "MC" == result.type
-        assert 2 == len(result.and_conditions)
-        assert "-" == result.and_conditions[0].operator
-        assert "+" == result.and_conditions[1].operator
+        assert result.type == "MC"
+        assert len(result.and_conditions) == 2
+        assert result.and_conditions[0].operator == "-"
+        assert result.and_conditions[1].operator == "+"
         other_cond = result.other_condition
         assert other_cond is not None
-        assert 2 == len(other_cond.and_conditions)
-        assert "+" == other_cond.and_conditions[0].operator
-        assert "(0068,6590)" == other_cond.and_conditions[0].tag
-        assert "+" == other_cond.and_conditions[1].operator
-        assert "(0068,62C0)" == other_cond.and_conditions[1].tag
+        assert len(other_cond.and_conditions) == 2
+        assert other_cond.and_conditions[0].operator == "+"
+        assert other_cond.and_conditions[0].tag == "(0068,6590)"
+        assert other_cond.and_conditions[1].operator == "+"
+        assert other_cond.and_conditions[1].tag == "(0068,62C0)"
 
     def test_other_condition2(self, parser):
         result = parser.parse(
@@ -705,22 +703,22 @@ class ComplicatedConditionParserTest:
             "Pixel Data (7FE0,0010) or Pixel Data Provider URL (0028,7FE0) "
             "is present."
         )
-        assert "MC" == result.type
-        assert 2 == len(result.and_conditions)
-        assert "+" == result.and_conditions[0].operator
+        assert result.type == "MC"
+        assert len(result.and_conditions) == 2
+        assert result.and_conditions[0].operator == "+"
         or_conditions = result.and_conditions[1].or_conditions
-        assert 2 == len(or_conditions)
-        assert "+" == or_conditions[0].operator
-        assert "(7FE0,0010)" == or_conditions[0].tag
-        assert "+" == or_conditions[1].operator
-        assert "(0028,7FE0)" == or_conditions[1].tag
+        assert len(or_conditions) == 2
+        assert or_conditions[0].operator == "+"
+        assert or_conditions[0].tag == "(7FE0,0010)"
+        assert or_conditions[1].operator == "+"
+        assert or_conditions[1].tag == "(0028,7FE0)"
         other_cond = result.other_condition
         assert other_cond is not None
-        assert 2 == len(other_cond.or_conditions)
-        assert "+" == other_cond.or_conditions[0].operator
-        assert "(7FE0,0010)" == other_cond.or_conditions[0].tag
-        assert "+" == other_cond.or_conditions[1].operator
-        assert "(0028,7FE0)" == other_cond.or_conditions[1].tag
+        assert len(other_cond.or_conditions) == 2
+        assert other_cond.or_conditions[0].operator == "+"
+        assert other_cond.or_conditions[0].tag == "(7FE0,0010)"
+        assert other_cond.or_conditions[1].operator == "+"
+        assert other_cond.or_conditions[1].tag == "(0028,7FE0)"
 
     def test_possible_false_positive(self, parser):
         # the "nested" had been parsed as value
@@ -729,7 +727,7 @@ class ComplicatedConditionParserTest:
             "Selector Attribute (0072,0026) is nested in one "
             "or more Sequences or is absent"
         )
-        assert "U" == result.type
+        assert result.type == "U"
 
     def test_sop_class_matching(self, parser):
         # this tests several problems: usage of SOP Class instead of
@@ -747,21 +745,21 @@ class ComplicatedConditionParserTest:
             "May be present for other SOP Classes if Patient Orientation "
             "Code Sequence (0054,0410) is not present. "
         )
-        assert "MC" == result.type
-        assert 2 == len(result.and_conditions)
-        assert "-" == result.and_conditions[0].operator
-        assert "(0054,0410)" == result.and_conditions[0].tag
-        assert "=" == result.and_conditions[1].operator
-        assert "(0008,0016)" == result.and_conditions[1].tag
-        assert [
+        assert result.type == "MC"
+        assert len(result.and_conditions) == 2
+        assert result.and_conditions[0].operator == "-"
+        assert result.and_conditions[0].tag == "(0054,0410)"
+        assert result.and_conditions[1].operator == "="
+        assert result.and_conditions[1].tag == "(0008,0016)"
+        assert result.and_conditions[1].values == [
             "1.2.840.10008.5.1.4.1.1.2",
             "1.2.840.10008.5.1.4.1.1.4",
             "1.2.840.10008.5.1.4.1.1.2.1",
             "1.2.840.10008.5.1.4.1.1.4.1",
             "1.2.840.10008.5.1.4.1.1.4.3",
             "1.2.840.10008.5.1.4.1.1.4.2",
-        ] == result.and_conditions[1].values
+        ]
         other_cond = result.other_condition
         assert other_cond
-        assert "-" == other_cond.operator
-        assert "(0054,0410)" == other_cond.tag
+        assert other_cond.operator == "-"
+        assert other_cond.tag == "(0054,0410)"

--- a/dicom_validator/tests/spec_reader/test_part4_reader.py
+++ b/dicom_validator/tests/spec_reader/test_part4_reader.py
@@ -25,7 +25,7 @@ def reader(fs, doc_contents):
 
 
 @pytest.mark.usefixtures("fs")
-class TestPart4ReaderTest:
+class TestPart4Reader:
     def test_read_incomplete_doc_file(self, fs):
         spec_path = Path("/var/dicom/specs")
         spec_path.mkdir(parents=True)

--- a/dicom_validator/tests/validator/test_dicom_file_validator.py
+++ b/dicom_validator/tests/validator/test_dicom_file_validator.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from pydicom import write_file
-from pydicom.dataset import Dataset, FileDataset
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 
 from dicom_validator.validator.dicom_file_validator import DicomFileValidator
 
@@ -15,10 +15,10 @@ def validator(iod_info, module_info):
 
 
 @pytest.mark.usefixtures("fs")
-class FakeDicomFileValidatorTest:
+class TestFakeDicomFileValidator:
     @staticmethod
     def create_metadata():
-        metadata = Dataset()
+        metadata = FileMetaDataset()
         metadata.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.7"
         metadata.MediaStorageSOPInstanceUID = "1.2.3"
         metadata.TransferSyntaxUID = "1.2.840.10008.1.2"

--- a/dicom_validator/tests/validator/test_iod_validator.py
+++ b/dicom_validator/tests/validator/test_iod_validator.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from pydicom.dataset import Dataset
+from pydicom.dataset import Dataset, FileMetaDataset
 
 from dicom_validator.validator.iod_validator import IODValidator
 
@@ -14,7 +14,7 @@ def new_data_set(tags):
     data_set = Dataset()
     for tag_name, value in tags.items():
         setattr(data_set, tag_name, value)
-    data_set.file_meta = Dataset()
+    data_set.file_meta = FileMetaDataset()
     data_set.is_implicit_VR = False
     data_set.is_little_endian = True
     return data_set
@@ -31,7 +31,7 @@ def validator(iod_info, module_info, request):
     return IODValidator(data_set, iod_info, module_info, None, logging.ERROR)
 
 
-class IODValidatorTest:
+class TestIODValidator:
     """Tests IODValidator.
     Note: some of the fixture data are not consistent with the DICOM Standard.
     """
@@ -70,7 +70,7 @@ class IODValidatorTest:
         # PatientName is set
         assert not self.has_tag_error(result, "Patient", "(0010,0010)", "missing")
         # PatientSex - type 2, missing
-        assert not self.has_tag_error(result, "Patient", "(0010,0040)", "missing")
+        assert self.has_tag_error(result, "Patient", "(0010,0040)", "missing")
         # Clinical Trial Sponsor Name -> type 1, but module usage U
         assert not self.has_tag_error(result, "Patient", "(0012,0010)", "missing")
         # Patient Breed Description -> type 2C, but no parsable condition


### PR DESCRIPTION
- many tests have been disabled accidentally after moving them to pytest
- use correct order in assertions
- avoid deprecation warning from pydicom

(noticed this while adding new tests)