### PR TITLE
Add initial support for handling functional groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ The released versions correspond to PyPi releases.
 
 ## [Version 0.4.0] (Unreleased)
 
+### Features
+* added initial support for validating functional group macros
+
 ### Infrastructure
 * Added pre-commit configuration for use with pre-commit hook
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 ## Reader
 
 #### Module definition tables from part 3
-* handle functional groups
-* basic/enhanced, more? additional attributes
 * handle other SOP classes not in the table (presentation states etc.)
 
 #### Parse attribute description

--- a/dicom_validator/tests/conftest.py
+++ b/dicom_validator/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from dicom_validator.spec_reader.edition_reader import EditionReader
+from dicom_validator.spec_reader.part6_reader import Part6Reader
 
 CURRENT_REVISION = "2021d"
 
@@ -55,3 +56,14 @@ def disable_logging():
     logging.disable(logging.CRITICAL)
     yield
     logging.disable(logging.DEBUG)
+
+
+@pytest.fixture(scope="module")
+def spec_path(fs_module, spec_fixture_path):
+    fs_module.add_real_directory(spec_fixture_path)
+    yield spec_fixture_path
+
+
+@pytest.fixture
+def dict_reader(spec_path):
+    yield Part6Reader(spec_path)

--- a/dicom_validator/tests/fixtures/2021d/docbook/part03.xml
+++ b/dicom_validator/tests/fixtures/2021d/docbook/part03.xml
@@ -15374,6 +15374,199 @@
                   </tr>
                 </tbody>
               </table>
+                    <table frame="box" label="C.7-17a" rules="all" xml:id="table_C.7-17a">
+                        <caption>Display Shutter Macro Attributes</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_482e6553-585d-4edb-ba59-648143cd366e">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ce75e68f-b2cc-4f09-944c-aee503ab0d9b">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_790032f2-fbce-4f69-8723-40da4fde61a0">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_eaaf124f-4977-473a-aa9e-7f0ce1297a7c">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7b7697cb-2c0d-470c-a00c-6cc2eab9f556">Shutter Shape</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_0f85b27f-18fe-4bcc-8614-6e36faa58a49">(0018,1600)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_8d3093f2-0615-42fb-a544-5a9757b3d56d">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_b087edb6-64e1-48fc-be41-6482ff55ea47">Shape(s) of the shutter defined for display.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>RECTANGULAR</term>
+                                            <listitem>
+                                                <para xml:id="para_ae6d571e-757d-457a-943e-2382180a1094"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>CIRCULAR</term>
+                                            <listitem>
+                                                <para xml:id="para_084831a1-37a3-4f0a-a20b-a6134a52bc41"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>POLYGONAL</term>
+                                            <listitem>
+                                                <para xml:id="para_e9c926f7-23c9-40a0-bd83-bd1def3671df"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_02feab2b-bb1c-41a7-a630-a7ca6d9251d3">This multi-valued Attribute shall contain at most one of each Enumerated Value. When multiple values are present, and the shutter is applied to a displayed image, then all of the shapes shall be combined and applied simultaneously, that is, the least amount of image remaining shall be visible (unoccluded). See <xref linkend="figure_C.7-4b" xrefstyle="select: label"/>.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_e3cd11ad-8094-4ff8-99be-4440dd959695">Shutter Left Vertical Edge</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_56faf8c0-2b6e-4446-ab14-9a544dff00c5">(0018,1602)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_4c25430a-f577-4fe2-9e58-0472f11f5b18">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_83a7e13e-a941-43ee-9af7-232928f81557">Required if Shutter Shape (0018,1600) is RECTANGULAR. Location of the left edge of the rectangular shutter with respect to pixels in the image given as column.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_4a5860cb-107d-4f5b-b995-cb6ed3092ab8">Shutter Right Vertical Edge</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f380686a-6225-499b-9d4f-00653a793090">(0018,1604)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e43b8ff5-9234-487f-89b7-111388bd2b8f">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_22f8e01e-5d18-44dc-9948-573dfd430111">Required if Shutter Shape (0018,1600) is RECTANGULAR. Location of the right edge of the rectangular shutter with respect to pixels in the image given as column.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_a0e9c3d7-4d93-4b73-bdc5-ba50a94af427">Shutter Upper Horizontal Edge</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_de4245d7-d4cd-4f49-98cb-e3f525f72a2a">(0018,1606)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_2b0be8d5-cc01-4f2c-adb4-02ee10b0cda0">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_a3320b73-7449-483f-a010-3c66c19b9da9">Required if Shutter Shape (0018,1600) is RECTANGULAR. Location of the upper edge of the rectangular shutter with respect to pixels in the image given as row.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_db69f09a-d692-47d7-9ec4-0f971bd12ecd">Shutter Lower Horizontal Edge</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a12ff0db-7a05-4135-9a0c-92d098aa4c09">(0018,1608)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_c48f4079-ec11-4b6b-b7ab-06eddf30f689">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_fd102576-ee1f-42dc-995a-9aaf545f2279">Required if Shutter Shape (0018,1600) is RECTANGULAR. Location of the lower edge of the rectangular shutter with respect to pixels in the image given as row.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_fefd015e-330f-490c-b746-bd04608489bc">Center of Circular Shutter</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_2aa3ac50-1278-4a84-b675-891da580852f">(0018,1610)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_3618993b-3234-4ed5-8bd0-c6eae9a9bbef">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_190ffbf1-d417-476b-bb6a-738c1a0efd09">Required if Shutter Shape (0018,1600) is CIRCULAR. Location of the center of the circular shutter with respect to pixels in the image given as row and column.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_973b267c-fc15-472a-9372-39f59b2da752">Radius of Circular Shutter</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_21339f45-3799-45bf-8eb9-9a0794b841f3">(0018,1612)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d72bb12c-d452-443c-996d-9243af1cf1d4">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_569362aa-79e9-4195-bcf4-49c1e8f8a5d8">Required if Shutter Shape (0018,1600) is CIRCULAR. Radius of the circular shutter with respect to pixels in the image given as a number of pixels along the row direction.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_92627998-7ab3-48f3-9361-9439fa39e1e2">Vertices of the Polygonal Shutter</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_cb248e54-9dee-41a9-886c-15fc32079ca5">(0018,1620)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_890a19f9-1010-4afc-a11d-0e436ac45493">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2696be1a-dc79-4429-b2bb-42f70b5dbb2b">Required if Shutter Shape (0018,1600) is POLYGONAL.</para>
+                                    <para xml:id="para_2b7f59e4-f147-472c-a1f5-74abbce118c4">Multiple Values where the first set of two values are:</para>
+                                    <itemizedlist mark="none">
+                                        <listitem>
+                                            <para xml:id="para_d59cd0c0-b975-4ac4-adee-bb16895e809c">row of the origin vertex\column of the origin vertex</para>
+                                        </listitem>
+                                    </itemizedlist>
+                                    <para xml:id="para_0f56382b-ebfa-48ca-bfec-3c552c733482">Two or more pairs of values follow and are the row and column coordinates of the other vertices of the polygon shutter. Polygon shutters are implicitly closed from the last vertex to the origin vertex and all edges shall be non-intersecting except at the vertices.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_1efccf44-92d1-4a50-898a-0f2338f0fe6a">Shutter Presentation Value</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_2ca38063-8b35-4aec-a7c6-d4d9d641e765">(0018,1622)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_104d3a0f-5c0e-4ec0-a880-7c895cc74abb">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_d07fea2b-ea29-412f-a234-9a5866923a41">A single gray unsigned value used to replace those parts of the image occluded by the shutter, when rendered on a monochrome display. The units are specified in P-Values, from a minimum of 0000H (black) up to a maximum of FFFFH (white).</para>
+                                    <note>
+                                        <para xml:id="para_ffd1df8a-26f5-4fb0-aeb7-f15acf3c3a88">The maximum P-Value for this Attribute may be different from the maximum P-Value from the output of the Presentation LUT, which may be less than 16 bits in depth.</para>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7c2967b4-f794-437b-a4f1-bd106e196061">Shutter Presentation Color CIELab Value</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b8833899-da06-4dde-95f4-94bcff1da974">(0018,1624)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_9f46322d-ed21-46d3-8172-f3fce9637ef2">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_261a96b2-5a4a-4d06-bd76-94b34de24588">A color triplet value used to replace those parts of the image occluded by the shutter, when rendered on a color display. The units are specified in PCS-Values, and the value is encoded as CIELab. See <xref linkend="sect_C.10.7.1.1" xrefstyle="select: label"/>.</para>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
             </section>
             <section label="C.7.6.16.2.17" status="6" xml:id="sect_C.7.6.16.2.17">
               <title>Respiratory Synchronization Macro</title>
@@ -25321,6 +25514,4047 @@
           </section>
         </section>
       </section>
+            <section label="C.8.19" status="3" xml:id="sect_C.8.19">
+                <title>Enhanced XA/XRF Image</title>
+                <section label="C.8.19.1" status="4" xml:id="sect_C.8.19.1">
+                    <title>XA/XRF Series Module</title>
+                    <para xml:id="para_94d9dcb8-e0af-4dde-b196-f332a2a7e3a9">The XA/XRF X-Ray IODs use the <xref linkend="sect_C.7.3.1" xrefstyle="select: title"/>, specialized by the XA/XRF Series Module, to describe the DICOM Series Entity specified in <xref linkend="sect_A.47" xrefstyle="select: label"/> and <xref linkend="sect_A.48" xrefstyle="select: label"/>. It is defining what constitutes a Series for the context of projection XA/XRF device.</para>
+                    <para xml:id="para_36beb081-51f8-444a-a431-924991ed52fa">
+                        <xref linkend="table_C.8.19.1-1" xrefstyle="select: label"/> specifies the Attributes that identify and describe general information about the XA/XRF Series.</para>
+                    <table frame="box" label="C.8.19.1-1" rules="all" xml:id="table_C.8.19.1-1">
+                        <caption>XA/XRF Series Module Attributes</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e0e6b6ab-6b7d-45a2-b972-c73b9324a8be">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d46c4c58-8c2f-49e9-b997-7de199f3d655">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_6114bd37-785f-4176-8daa-e6f6f459ede7">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_6602e7ef-e597-48dc-9b99-1fbd44538ccf">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2db4ce7a-0453-4539-9c56-6f2241437d98">Modality</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_38e786b6-24df-4f3c-9984-6c2c35493b80">(0008,0060)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_40b6a4bb-ed76-42f5-bceb-78d26aec2e44">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_044fe0ab-4e5b-4e8b-9393-a43e0a940ef8">Type of device, process or method that originally acquired the data used to create the images in this Series.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>XA</term>
+                                            <listitem>
+                                                <para xml:id="para_9fd0d7c5-0c4d-4f80-be9c-6eba80fefb31"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>RF</term>
+                                            <listitem>
+                                                <para xml:id="para_24e9ba8f-c9e4-4929-ba34-67c8d7f85e16"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_45af4760-e4d8-45a9-a914-d5a2c99cb51d">See <xref linkend="sect_C.7.3.1.1.1" xrefstyle="select: label"/> for further explanation.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7c77f6ec-e4f6-4b60-a826-850539b9305f">Series Number</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_3ab5285a-34d4-4d7d-b457-49a9c3a7fb21">(0020,0011)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_075d7b82-77eb-47b5-b8e7-8f26be298bdf">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_cfe93f3f-7152-4143-a23e-436906834420">A number that identifies this Series.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_94355ecf-bff7-491a-9478-d2ddfbe9ccb1">Referenced Performed Procedure Step Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_101c432e-8051-4bc5-a1c9-1a7593503bad">(0008,1111)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f67a0446-58cf-47bb-83ee-d44e72356fc7">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_eccff359-90db-45a3-91ba-2b4ade42844c">Uniquely identifies the Performed Procedure Step SOP Instance to which the Series is related.</para>
+                                    <para xml:id="para_d37d1403-0087-4733-8374-1897f44adfca">Only a single Item shall be included in this Sequence.</para>
+                                    <para xml:id="para_68f30010-4600-46d6-aa31-807cd3d64730">Required if a Performed Procedure Step SOP Class was involved in the creation of this Series.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_fd7c1194-f70d-43c3-9d74-3e49d71870e4">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_10-11" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_84749a39-6377-4892-800f-0b1acbaaa7e7"/>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section label="C.8.19.2" status="4" xml:id="sect_C.8.19.2">
+                    <title>Enhanced XA/XRF Image Module</title>
+                    <para xml:id="para_93bd249c-124e-4d35-bf70-93edba23901b">This section describes the Enhanced XA/XRF Image Module. <xref linkend="table_C.8.19.2-1" xrefstyle="select: label"/> contains IOD Attributes that describe a XA/XRF Image by specializing Attributes of the <xref linkend="sect_C.7.6.1" xrefstyle="select: title"/> and <xref linkend="sect_C.7.6.3" xrefstyle="select: title"/>, and adding additional Attributes.</para>
+                    <table frame="box" label="C.8.19.2-1" rules="all" xml:id="table_C.8.19.2-1">
+                        <caption>Enhanced XA/XRF Image Module Table</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f11f224a-666e-48c4-9a5d-39bc88d6c5ab">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_c614c503-d8a6-4e46-be00-519ec178fe31">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_165cc6bc-1789-4f6c-9d60-fe2e0303ef5b">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_6c3cac6a-b663-40aa-a599-c6b7165f39c6">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_ef525924-5aaa-446c-a6a6-fef4e89f528c">Image Type</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_96e0ae8f-b696-40af-80dd-b478dfce7055">(0008,0008)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_0528c987-3efa-477f-a978-af04c50bc288">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_316be70e-8bf4-4a13-b5b9-cf087d397cd8">Image identification characteristics.</para>
+                                    <para xml:id="para_7c603e61-94bb-4eb2-b471-5b3add9d6bc5">See <xref linkend="sect_C.8.19.2.1.1" xrefstyle="select: label"/> for specialization.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_95fd7495-0519-46d1-a294-b6053e8215b6">Planes in Acquisition</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_abdcda41-8ed0-4042-847b-a73fae2a3cdb">(0018,9410)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_bb3a46a3-88c1-446d-b636-ca4b1305e0eb">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7794d385-908a-4e37-b9da-24493a7d121e">The multiplicity of planes used simultaneously during the acquisition. See <xref linkend="sect_C.8.19.2.1.3" xrefstyle="select: label"/>.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_5ea5c42c-8351-46fe-b72c-031456a37526">Plane Identification</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_c339728f-39c7-4515-90e6-df5e03d0a35e">(0018,9457)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_7a499228-33c5-486a-969a-7cb6d24da2d9">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_df9a55b1-fdd7-484a-b104-e5a7e857fdfa">Identification of the plane used to acquire this image.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>MONOPLANE</term>
+                                            <listitem>
+                                                <para xml:id="para_94446176-b8cb-4799-bc57-99d89dd38da3"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>PLANE A</term>
+                                            <listitem>
+                                                <para xml:id="para_c5964da9-e330-499e-8054-d6adedfe6193"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>PLANE B</term>
+                                            <listitem>
+                                                <para xml:id="para_9e4b3510-5a3e-4ba6-a0b2-9458cecb5fcf"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <note>
+                                        <orderedlist numeration="arabic">
+                                            <listitem>
+                                                <para xml:id="para_53dd8f59-93c7-46f6-a141-c48acf32e902">MONOPLANE is only permitted to be used for a single plane system</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_9a5d6d20-19eb-4edf-977b-7388e5c6f560">PLANE A and PLANE B must be used for two plane systems, independent if the acquisition is single plane or biplane.</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_1fb1d999-39ac-4acc-ac11-d40e744e70b9">The value has to be in accordance with the value of Planes in Acquisition (0018,9410). If this value is SINGLE PLANE all three Defined Term are applicable.</para>
+                                            </listitem>
+                                        </orderedlist>
+                                    </note>
+                                    <para xml:id="para_71078040-05d0-4420-aad7-b44bcb3661ab">Required if Planes in Acquisition (0018,9410) is not equal to UNDEFINED.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_f3665714-d7be-4b9a-8ee4-d0133f289929">Acquisition Number</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_35923437-803e-4e1f-8d46-ccb370485e3c">(0020,0012)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ee013144-43cb-4aa9-947a-7d372bf81d7b">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_79b8d48a-d607-4f23-877b-b265ff3401d3">A number identifying the single continuous gathering of data over a period of time that resulted in this image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_9ebf5b92-499d-4bf0-a9e3-01439aec1db8">Acquisition DateTime</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_aaadc841-a2b4-45d1-b673-fc2c122bc9ca">(0008,002A)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_fabfdfa4-328f-4c7b-a146-d33a14d2b470">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_98d24019-e9a6-4ae6-aae4-14d5c46b28d6">The date and time that the acquisition of data that resulted in this image started.</para>
+                                    <note>
+                                        <para xml:id="para_08c90ba7-61c6-4cf9-94c7-a9076c248f35">The synchronization of this time with an external clock is specified in the <xref linkend="sect_C.7.4.2" xrefstyle="select: title"/> in Acquisition Time Synchronized (0018,1800).</para>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_02c2c955-2457-4863-926c-db1f40b80164">Bits Allocated</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_77f01f9a-e42d-4da6-a497-0f980bdf8d88">(0028,0100)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f7760cd7-9863-4ae0-a66d-5c5d2c691c24">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_5c1ffd4c-b2f7-4b93-a4d8-21e34a8e0890">Number of bits allocated for each pixel sample. Each sample shall have the same number of bits allocated.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>8</term>
+                                            <listitem>
+                                                <para xml:id="para_ecba6778-6800-4c93-ab72-86ab712c4846"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>16</term>
+                                            <listitem>
+                                                <para xml:id="para_31d39f04-c3fc-4fb1-8eaf-b11a83cd61fd"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_413610d4-0302-4500-8147-c3eb415e9d7c">Bits Stored</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_4f5c7649-55c6-44c5-a77e-1ccbf51a293c">(0028,0101)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_cbc2784d-6a5e-411a-bbc0-bc8dc4f768bd">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_ad665469-94ae-460e-b98e-285efa65a14a">Number of bits stored for each pixel sample. Each sample shall have the same number of bits stored.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>8</term>
+                                            <listitem>
+                                                <para xml:id="para_04928e5b-c4a7-4488-a6b1-334c783512df"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>9</term>
+                                            <listitem>
+                                                <para xml:id="para_3296553a-e5a4-4c92-8d58-cf26197b9d63"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>10</term>
+                                            <listitem>
+                                                <para xml:id="para_a8d67e02-cc8a-4104-8be0-6bb5717dc788"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>11</term>
+                                            <listitem>
+                                                <para xml:id="para_d16a9ca3-e3cc-4d8d-b6df-cec808834162"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>12</term>
+                                            <listitem>
+                                                <para xml:id="para_3b5baaae-948f-4ac9-bd1a-ff4ddd6e899e"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>13</term>
+                                            <listitem>
+                                                <para xml:id="para_ab7187b2-c524-4b95-a278-2c98a1cacbce"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>14</term>
+                                            <listitem>
+                                                <para xml:id="para_6e72e087-677e-461c-bd58-693126d24020"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>15</term>
+                                            <listitem>
+                                                <para xml:id="para_ecd1be74-49a7-4b26-8b4d-302212037ad9"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>16</term>
+                                            <listitem>
+                                                <para xml:id="para_89a3beb4-6055-4507-9241-159fe53e57d2"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_9bfdac4e-d3a5-4da3-8ff9-8be10e1f1cc9">See <xref linkend="sect_C.8.19.2.1.2" xrefstyle="select: label"/> for specialization.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_6cbd3ef0-f26b-4a38-91ce-36fee470477a">High Bit</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_31c0dd16-a237-4637-9002-666b047c4b16">(0028,0102)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f05f616e-87d4-4294-899f-40f559d7efcb">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_28eace08-d49c-4cbe-b641-f9dd1992535d">Most significant bit for pixel sample data. Each sample shall have the same high bit. Shall be one less than the value in Bits Stored (0028,0101).</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_34ab572d-5c83-485f-a211-3556a4cc0cf6">Samples per Pixel</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_30a8893f-61cc-4556-9d51-f9295f11dfc4">(0028,0002)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ca591681-967e-47ef-9a99-7ff35b0e61fc">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2d8fc6b9-f787-4d40-a08d-1aa1336c5056">Number of samples (color planes) in this image shall have a value of 1.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_538d0aa0-c7d3-495d-a054-7d7317f00d2e">Pixel Representation</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_00af3722-a81e-49c7-ae01-e36c4b5886c3">(0028,0103)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_10b10b5d-ce29-4608-9615-d76c6ff64c00">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_cb99be66-282d-4900-a095-b60ac9b3e37c">Data representation of the pixel samples.</para>
+                                    <para xml:id="para_89c859db-4be9-4dca-a667-4463aea09800">Shall have the value:</para>
+                                    <para xml:id="para_6b330794-0081-4e82-a76c-a0ea59f409ce">0000H = Unsigned Integer.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_5d2fa8e9-f269-4b90-9e8c-827caf3b7867">Photometric Interpretation</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_26554e14-2dba-42ab-aac4-9d84b5916e32">(0028,0004)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d7c5a8e0-07f4-457e-84a8-e0cfe995e4f4">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_0010ca76-23b0-482a-8395-83c94090735d">Specifies the intended interpretation of the pixel data.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>MONOCHROME1</term>
+                                            <listitem>
+                                                <para xml:id="para_934fe5a2-526c-448d-a42f-dacb25aabe67"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>MONOCHROME2</term>
+                                            <listitem>
+                                                <para xml:id="para_79e0dcf0-f6a9-424b-ba9a-434e40bab6e7"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_0be58cdc-509d-452d-bf13-dbc2eedfd012">Acquisition Protocol Name</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a7525321-5df4-465b-9b80-2512560326b6">(0018,9423)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_1949320c-dcd8-4c7b-adb6-66f236755f8f">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7dac9db3-0716-4c22-b139-9f5e3a6840af">User defined name of the protocol used to acquire this image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_1d3e0dea-90c6-424e-8302-b89cde7b483a">Acquisition Protocol Description</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_16624a19-4267-4c5f-8535-1c67dce42b73">(0018,9424)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_1ade847d-dc65-47a9-ad6f-c85b1e0dbb41">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_0f9fdca7-c3d9-4f0f-871a-1b5ba27e3734">User defined description of the protocol used to acquire this image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_69c052d3-bb91-40b2-8f08-f87c04e11489">Scan Options</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e076a96e-ef67-4498-a17f-8fcfd834b4aa">(0018,0022)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_90ee7ebc-cdc1-4887-87e6-1e62af6cf1da">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_06142e28-9093-4a22-b008-bd72f800a73b">Identifies any acquisition technique that was used during the acquisition of the image.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>TOMO</term>
+                                            <listitem>
+                                                <para xml:id="para_7bd1d04f-1a14-4d96-b151-1964c61b4252">Tomography</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>CHASE</term>
+                                            <listitem>
+                                                <para xml:id="para_bf01f1e8-338d-4c0b-ac71-001b5d5a7530">Bolus Chasing</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>STEP</term>
+                                            <listitem>
+                                                <para xml:id="para_7f343d67-0ac5-4828-91f1-1a889c6028ef">Stepping</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>ROTA</term>
+                                            <listitem>
+                                                <para xml:id="para_e58b9ae9-2bcd-46c8-85cc-3af8ca2a4838">Rotation</para>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_8a49828f-a243-4484-8122-49ad70f42679">Content Qualification</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a12927a0-b51a-4de9-a59a-4c300b5ba157">(0018,9004)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f69cc963-1885-45cd-9c70-7bbbf2a51257">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_29a699ef-0d6c-44c7-b67a-eed098c9ecb8">Content Qualification Indicator</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>PRODUCT</term>
+                                            <listitem>
+                                                <para xml:id="para_2a82e595-dded-4357-9cb4-ee18454b4729"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>RESEARCH</term>
+                                            <listitem>
+                                                <para xml:id="para_613d8330-59c0-4b7c-a938-c513fc4b2265"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>SERVICE</term>
+                                            <listitem>
+                                                <para xml:id="para_560454de-8bbd-4039-9d1b-91d7a1fc8baf"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_3e477c0f-d571-4be4-9501-95a99a02ecae">See <xref linkend="sect_C.8.13.2.1.1" xrefstyle="select: label"/> for further explanation.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_05f3515e-5e7f-4f1d-af06-e6720bfb06c7">Patient Orientation Code Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_14496736-7dca-405d-aedf-4670ea83a80b">(0054,0410)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e49ff483-65d3-4577-9a4a-4d08c15837b2">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_c74bc496-3e23-4104-ba16-5845008b1ed8">Sequence that describes the orientation of the patient with respect to gravity.</para>
+                                    <para xml:id="para_568d3521-bafa-4e5d-bfa5-9df03b7771dd">See <xref linkend="sect_C.8.11.5.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    <para xml:id="para_c359e65c-b4d8-4eee-b75a-0d91de91616a">Only a single Item shall be included in this Sequence.</para>
+                                    <para xml:id="para_ce79224d-1d53-4c8b-ae92-79416f285d6f">Required if Positioner Type (0018,1508) equals CARM and C-arm Positioner Tabletop Relationship (0018,9474) equals YES. May be present otherwise.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_bd28e701-c19c-4f6b-a633-f6fb47760b8d">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_8.8-1" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>.</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_c9665b2c-0e60-4d9a-903f-97fac5677720">
+                                        <emphasis role="italic">B<olink targetdoc="PS3.16" targetptr="sect_CID_19" xrefstyle="select: labelnumber quotedtitle"/>.</emphasis>
+                                    </para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_dea25d1d-9d0f-4903-a6d9-48e45e33b898">&gt;Patient Orientation Modifier Code Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_2b890898-8171-47f9-bcd3-44322ccdcb0e">(0054,0412)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d11d3c26-94f7-414f-9e5c-4ed337e30efa">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_807cf41a-80e1-4778-b4f7-9210706bded5">Patient Orientation Modifier.</para>
+                                    <para xml:id="para_5b52f6a2-a494-4b4a-aff7-fbc4f06165ff">Required if needed to fully specify the orientation of the patient with respect to gravity.</para>
+                                    <para xml:id="para_106f80a1-ecae-4ed6-a12a-18f9fc58878e">Only a single Item shall be included in this Sequence.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_dbf9e8bb-fc6e-4700-bca7-1d0cd567c644">
+                                        <emphasis role="italic">&gt;&gt;Include <xref linkend="table_8.8-1" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_829723fd-354a-4a2e-84b7-0844c5784e77">
+                                        <emphasis role="italic">B<olink targetdoc="PS3.16" targetptr="sect_CID_20" xrefstyle="select: labelnumber quotedtitle"/>.</emphasis>
+                                    </para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_099b94f7-2b12-4c8e-8b61-d584bd465636">Patient Gantry Relationship Code Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_226b4c94-5a4c-42ab-88b6-fa4d84fa66a3">(0054,0414)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_7b6c9179-0184-429d-b98c-3095d0516ecf">2C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_cedb7c44-5acc-48bc-81e7-c89ad6d46ebd">Sequence that describes the orientation of the patient with respect to the head of the table. See <xref linkend="sect_C.8.4.6.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    <para xml:id="para_76b5d73e-f9f8-412c-9906-6064a3ff1b29">Zero or one Item shall be included in this Sequence.</para>
+                                    <para xml:id="para_283a8002-4ee2-485f-9967-f08b88cf71bd">Required if Positioner Type (0018,1508) equals CARM and C-arm Positioner Tabletop Relationship (0018,9474) equals YES. May be present otherwise.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_f72cfc28-f25a-488c-b09a-6778af3c4868">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_8.8-1" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>.</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2c0877c6-84fc-4004-aa68-95da87b315ff">
+                                        <emphasis role="italic">B<olink targetdoc="PS3.16" targetptr="sect_CID_21" xrefstyle="select: labelnumber quotedtitle"/>.</emphasis>
+                                    </para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_bf4a7181-a2ca-4f21-9542-36e38f5f91a9">Examined Body Thickness</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ce810601-0fcc-4309-99c3-e972f6923ddd">(0010,9431)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b2d0c689-e79d-4aea-b3f5-4606be4f87bf">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_de151eeb-0413-4d57-94ce-f5e3596eba76">Body thickness in mm at examination location perpendicular to the table top for this Series.</para>
+                                    <note>
+                                        <orderedlist numeration="arabic">
+                                            <listitem>
+                                                <para xml:id="para_76e74037-75e3-4dec-b353-a1068421b36d">This is intended for estimation of the thickness of the patient at the tabletop, not for precise calculation of the size of the object in the X-Ray beam (see Calculated Anatomy Thickness (0018,9452) Attribute).</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_ea49ce7d-a4af-48fd-910a-406ec3be3d36">For example, used to estimate the value range of the Distance Object to Table Top (0018,9403) Attribute.</para>
+                                            </listitem>
+                                        </orderedlist>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_fbc4d01b-5ef9-468a-ba5d-55575fb397e8">Burned In Annotation</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_08f286d3-fd46-499c-9785-ec26bc9302a8">(0028,0301)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_da955c44-21b0-4a76-ad0f-29689ee89a54">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_af4eecf6-8862-4c22-856d-6daf80d61b0a">Indicates whether or not the image contains sufficient burned in annotation to identify the patient and date the image was acquired.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>NO</term>
+                                            <listitem>
+                                                <para xml:id="para_83c76a4b-356b-4218-ab58-39065f91ac59"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_39ee03c2-9db3-41a4-a1ea-55aeb47b711b">Recognizable Visual Features</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a7578644-1d66-4615-b6ed-d0209251b4a0">(0028,0302)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_535c20dc-ae75-4546-b0a0-107611b701b7">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_435d18d6-1316-49c1-ba7f-c09121538e82">Indicates whether or not the image contains sufficiently recognizable visual features to allow the image or a reconstruction from a set of images to identify the patient.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>YES</term>
+                                            <listitem>
+                                                <para xml:id="para_f324edd5-15a5-4270-9e54-92489d836e62"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>NO</term>
+                                            <listitem>
+                                                <para xml:id="para_c65f66ab-834e-402a-8b11-3afcf6340dff"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_893c63cb-49a1-4b51-be7a-03225c5fe91d">If this Attribute is absent, then the image may or may not contain recognizable visual features.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_56b3f7dc-f7a2-46a2-99ac-9c24e2733002">Lossy Image Compression</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a46b79c5-6f84-4952-95e2-f949afc1f61c">(0028,2110)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f754ddd7-2964-4cbd-a615-c3b8dd56935e">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_e80c28ef-f640-4b22-a82a-9bb24cc6ff40">Specifies whether an Image has undergone lossy compression (at a point in its lifetime).</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>00</term>
+                                            <listitem>
+                                                <para xml:id="para_e620cee0-5d6a-495a-b471-155845b0ccda">Image has NOT been subjected to lossy compression.</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>01</term>
+                                            <listitem>
+                                                <para xml:id="para_bce737eb-dd80-4db5-9775-5677455bdad2">Image has been subjected to lossy compression.</para>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_0d53fa43-ce70-4733-8349-92d730487615">Once this value has been set to 01 it shall not be reset.</para>
+                                    <para xml:id="para_530c1684-c898-4915-9051-6a6e7bf45c7a">See <xref linkend="sect_C.7.6.1.1.5" xrefstyle="select: label"/>.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7c496c74-8a99-47a7-a30d-4e0c3edc647b">Lossy Image Compression Ratio</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_3f58968c-9506-4b25-ba3c-d1dfe740593f">(0028,2112)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_43756825-4b8b-4798-8cef-e02a69978d1a">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_c679791f-dcb9-4472-b9c7-2f316558ce82">Describes the approximate lossy compression ratio(s) that have been applied to this image.</para>
+                                    <para xml:id="para_4f8bed9c-6119-44e5-aa52-6f78de510139">See <xref linkend="sect_C.7.6.1.1.5.2" xrefstyle="select: label"/>.</para>
+                                    <para xml:id="para_0b3bbd1c-0b5e-49aa-8217-ef1768413a4b">Required if Lossy Image Compression (0028,2110) is "01".</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_e3a2ed79-1074-4bbd-af7e-6239997407b3">Lossy Image Compression Method</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_479422a4-45fa-4f08-ba1f-192061994f91">(0028,2114)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_8f8bcd69-e838-445d-9759-f8e027441ad3">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_54bbcf41-d11b-4a41-8462-64b75e5cc8a7">A label for the lossy compression method(s) that have been applied to this image.</para>
+                                    <para xml:id="para_ec032634-939b-4356-8d52-a80bec4797bd">See <xref linkend="sect_C.7.6.1.1.5.1" xrefstyle="select: label"/>.</para>
+                                    <para xml:id="para_3ae247b6-c18c-4da4-8d82-6e20c54f3fb7">Required if Lossy Image Compression (0028,2110) is "01".</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_77580784-c83e-45c1-9c57-60e3f6f5611f">Referenced Other Plane Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ab67358c-9b34-4d84-8d54-8e0fdb285c71">(0008,9410)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_72fb9f56-edfc-400f-8adc-d1849baab903">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_dc3c97fb-b3a5-4ad5-8687-d1053afeb845">The images of the corresponding plane for a Biplane acquisition device.</para>
+                                    <para xml:id="para_c334c0fd-7cac-4e5c-82c5-1c32953a0780">Only a single Item shall be included in this Sequence.</para>
+                                    <para xml:id="para_2e6476e3-2f3a-424f-ade8-7c93aca233c3">Required if Planes in Acquisition (0018,9410) is BIPLANE.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_87008bfb-9a1b-43e0-bec5-90cc872afdae">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_10-3" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_dc9357ab-08cc-4ecf-aff2-a172e1643fe3"/>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_b2c8835b-9522-4b03-b0f4-bf6b54c482ca">Referenced Image Evidence Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_1562749b-5698-4535-88d6-c3c5c27b51d0">(0008,9092)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_95e14e6c-4caa-4082-955b-636550617ff6">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_44c639b9-94c5-41bd-8b4d-747e03602f2e">Full set of Composite SOP Instances referred to inside the Referenced Image Sequences of this SOP Instance. See <xref linkend="sect_C.8.13.2.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    <para xml:id="para_53e03a31-738f-4ce8-b595-a1f46357dd51">One or more Items shall be included in this Sequence.</para>
+                                    <para xml:id="para_c2f4f090-ad49-4895-a5d6-50c0b77d2d67">Required if the Referenced Image Sequence (0008,1140) is present.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_77dc8e4b-08ca-455e-b8b9-3498f42407c4">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_C.17-3" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_49643d84-fba5-4d46-82b4-5b0afa776e94"/>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2aee83cf-29ef-4203-a179-4cb65f358d7e">Source Image Evidence Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_20f521e3-35c5-47ae-8cd1-a9d9c0b53578">(0008,9154)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ac49b92f-ea9e-4386-987e-4f13d90ed797">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_1bf0bf71-0eb3-475b-b029-2de01ad4ae13">Full set of Composite SOP Instances referred to inside the Source Image Sequences of this SOP Instance. See <xref linkend="sect_C.8.13.2.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    <para xml:id="para_9b6d5545-1240-4fd6-8672-d0c69d035665">One or more Items shall be included in this Sequence.</para>
+                                    <para xml:id="para_422803f6-23fc-4bd4-b200-60ac36a929a0">Required if the Source Image Sequence (0008,2112) is present.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_b7c5902f-1b5c-457c-bd94-b54f8928546d">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_C.17-3" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_90501f3c-d207-43d7-b1c0-38a65654564d"/>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_f7f172fc-afeb-4c1a-b7a2-4084558fbbfd">Referenced Instance Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_81898634-4d70-45c6-ab09-4298da6922e1">(0008,114A)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_8c646ee5-cefc-4a33-95c6-54a7462a535c">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_05264a78-a1fc-4367-930c-ff801a02640c">Non-image Composite SOP Instances that are significantly related to this Image, including waveforms that may or may not be temporally synchronized with this image.</para>
+                                    <para xml:id="para_e01e32f3-c312-4698-8c8e-acb759d84e41">One or more Items are permitted in this Sequence.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_1658c465-e613-4c27-a024-59b0049596bb">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_10-11" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_a051f229-5bd3-45cf-a1f7-eab6a6edabb2"/>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_5b093d7a-794d-4a54-bb51-fa43f86f967a">&gt;Purpose of Reference Code Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f7489d2c-a550-4104-b5ff-90aab738f898">(0040,A170)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ca793928-5fe6-4749-96bd-85d8480e0953">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_28681486-762a-469c-a3c6-4d63ab2e75a7">Code describing the purpose of the reference to the SOP Instances.</para>
+                                    <para xml:id="para_e32271c5-963b-42e8-8ade-f7fee33a25cd">Only a single Item shall be included in this Sequence.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_55236d94-8dc0-4550-8aad-3c0b0e053daf">
+                                        <emphasis role="italic">&gt;&gt;Include <xref linkend="table_8.8-1" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_304281a9-3d48-4fd0-89c4-726a0e56a3c2">
+                                        <emphasis role="italic">D<olink targetdoc="PS3.16" targetptr="sect_CID_7004" xrefstyle="select: labelnumber quotedtitle"/> for referenced waveforms.</emphasis>
+                                    </para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_76487d1b-ba6a-44a3-950c-b12e9d32e661">
+<emphasis role="italic">Include <xref linkend="table_10.41-1" xrefstyle="select: label quotedtitle"/>
+</emphasis>
+</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_da36f61c-5470-469c-821f-ab6940e5e6e7"/>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_8e0a2fc4-d9da-4d9b-a2de-d9f3cc0dc58b">Image Comments</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b1ad1d35-ce99-49e7-9f3c-414a28533d87">(0020,4000)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_294e4dd5-5766-4f56-8174-82742707ec5f">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_e98ac48a-5933-41ae-8dcd-053bc969baaa">User-defined comments about the image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_10deb4fd-7cfe-4829-a5c4-ece7a9d51dfe">Quality Control Image</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f7bd413b-3477-461a-8b77-d053e0474a5c">(0028,0300)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a7dc92ee-6802-41a6-83e1-9354a457bf6a">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_9d67a0a1-20ee-4ffa-9cf8-172839e14045">Indicates whether or not this image is a quality control or phantom image.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>YES</term>
+                                            <listitem>
+                                                <para xml:id="para_2bac05e0-5f11-4c28-b7e6-d1d0771d2c41"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>NO</term>
+                                            <listitem>
+                                                <para xml:id="para_5f149995-7d1f-4722-a586-523158a8ed77"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <para xml:id="para_a258cb69-451e-4b64-baa4-2f4ba7369ac2">If this Attribute is absent, then the image may or may not be a quality control or phantom image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_d79361e0-d6d7-4c9e-b7df-763c1cfa5a4d">Icon Image Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_462002d9-65bc-4f7f-9d4e-75f4d336c777">(0088,0200)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_97f2a85c-84e7-4c5e-8f6b-b6974684ae91">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_92256ba6-18e9-47b6-ada1-ef1c46b8ee3a">This icon image is representative of the Image.</para>
+                                    <para xml:id="para_67b39a7a-b796-4a17-baa3-6847e0c66a93">Only a single Item is permitted in this Sequence.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_fd6bb116-086d-4c31-a136-e81ded829f99">
+                                        <emphasis role="italic">&gt;Include <xref linkend="table_C.7-11b" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_29997bac-7970-4ccc-9c08-fa62ae63de5c">
+                                        <emphasis role="italic">See <xref linkend="sect_C.7.6.1.1.6" xrefstyle="select: label"/> for further explanation.</emphasis>
+                                    </para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_ad5909ad-b489-48a5-807d-a371f1a134cb">Presentation LUT Shape</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_937990e2-9ce4-4006-b9d5-2b284e2764b5">(2050,0020)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_03282d93-2ebf-4961-9523-b40eca35a894">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_81fd056e-c5a5-431b-8c7d-1e031e9e0b1d">Specifies a predefined identity transformation for the Presentation LUT such that the output of all grayscale transformations, if any, are defined to be in P-Values.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>IDENTITY</term>
+                                            <listitem>
+                                                <para xml:id="para_3988da3c-7247-4ed8-8d01-8dab177958c7">output is in P-Values - shall be used if Photometric Interpretation (0028,0004) is MONOCHROME2</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>INVERSE</term>
+                                            <listitem>
+                                                <para xml:id="para_7ec53b33-6072-4f66-835a-ef1ea3439b53">output after inversion is in P-Values - shall be used if Photometric Interpretation (0028,0004) is MONOCHROME1.</para>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <section label="C.8.19.2.1" status="5" xml:id="sect_C.8.19.2.1">
+                        <title>Enhanced XA/XRF Image Module Attribute Description</title>
+                        <section label="C.8.19.2.1.1" status="6" xml:id="sect_C.8.19.2.1.1">
+                            <title>Image Type and Frame Type</title>
+                            <para xml:id="para_19cbec27-c525-4292-987f-1ba4c0a0c704">In addition to the requirements specified in <xref linkend="sect_C.8.16.1" xrefstyle="select: label"/> Image Type, the following additional requirements and Defined Terms are specified.</para>
+                            <section label="C.8.19.2.1.1.1" status="7" xml:id="sect_C.8.19.2.1.1.1">
+                                <title>Pixel Data Characteristics</title>
+                                <para xml:id="para_f5456741-89ed-41ef-80e5-ff5f7bf94c35">Value 1 of Image Type (0008,0008) and Frame Type (0008,9007) is discussed in <xref linkend="sect_C.8.16.1.1" xrefstyle="select: label"/>. No additional requirements or Defined Terms.</para>
+                            </section>
+                            <section label="C.8.19.2.1.1.2" status="7" xml:id="sect_C.8.19.2.1.1.2">
+                                <title>Patient Examination Characteristics</title>
+                                <para xml:id="para_f9c3811d-7b5a-410b-8e25-87da659d29a0">Value 2 of Image Type (0008,0008) and Frame Type (0008,9007) is discussed in <xref linkend="sect_C.8.16.1.2" xrefstyle="select: label"/>. No additional requirements or Defined Terms.</para>
+                            </section>
+                            <section label="C.8.19.2.1.1.3" status="7" xml:id="sect_C.8.19.2.1.1.3">
+                                <title>Image Flavor</title>
+                                <para xml:id="para_0ce1ba3a-b19c-4af2-9507-65cc7168a907">Value 3 of Image Type (0008,0008) and Frame Type (0008,9007) is discussed in <xref linkend="sect_C.8.16.1.3" xrefstyle="select: label"/>. No additional requirements or Defined Terms.</para>
+                            </section>
+                            <section label="C.8.19.2.1.1.4" status="7" xml:id="sect_C.8.19.2.1.1.4">
+                                <title>Derived Pixel Contrast</title>
+                                <para xml:id="para_ef743076-9048-4360-a175-872dae53a1b1">Value 4 of Image Type (0008,0008) and Frame Type (0008,9007) is discussed in <xref linkend="sect_C.8.16.1.4" xrefstyle="select: label"/>. The value shall be NONE.</para>
+                            </section>
+                        </section>
+                        <section label="C.8.19.2.1.2" status="6" xml:id="sect_C.8.19.2.1.2">
+                            <title>Bits Allocated and Bits Stored</title>
+                            <para xml:id="para_630cbcc2-ea06-4994-8a88-033644da7e14">
+                                <xref linkend="table_C.8.19.2-2" xrefstyle="select: label"/> specifies the allowed combinations of Bits Allocated (0028,0100) and Bits Stored (0028,0101).</para>
+                            <table frame="box" label="C.8.19.2-2" rules="all" xml:id="table_C.8.19.2-2">
+                                <caption>Allowed Combinations of Attribute Values for Bits Allocated and Bits Stored</caption>
+                                <thead>
+                                    <tr valign="top">
+                                        <th align="center" colspan="1" rowspan="1">
+                                            <para xml:id="para_73f6b209-e6fc-4bf5-9a6a-1793aa352e60">Bits Allocated</para>
+                                        </th>
+                                        <th align="center" colspan="1" rowspan="1">
+                                            <para xml:id="para_787b6c7e-e8d3-469b-9485-8e9d2bdd43bf">Bits Stored</para>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr valign="top">
+                                        <td align="left" colspan="1" rowspan="1">
+                                            <para xml:id="para_91763823-b240-4c04-a936-78adee5774f5">8</para>
+                                        </td>
+                                        <td align="left" colspan="1" rowspan="1">
+                                            <para xml:id="para_073445d4-06b8-4daa-8178-b7ca6af27008">8</para>
+                                        </td>
+                                    </tr>
+                                    <tr valign="top">
+                                        <td align="left" colspan="1" rowspan="1">
+                                            <para xml:id="para_24d0c621-3d81-45ed-988a-07abe8fdb479">16</para>
+                                        </td>
+                                        <td align="left" colspan="1" rowspan="1">
+                                            <para xml:id="para_21b31ad6-1935-42e6-9aaf-a4786cc5e472">9 to 16</para>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </section>
+                        <section label="C.8.19.2.1.3" status="6" xml:id="sect_C.8.19.2.1.3">
+                            <title>Planes in Acquisition</title>
+                            <para xml:id="para_f004622a-4bde-4758-9f34-7cc8286ad407">The Planes in Acquisition (0018,9410) Attribute identifies the multiplicity of planes used simultaneously during the acquisition.</para>
+                            <variablelist spacing="compact">
+                                <title>Enumerated Values:</title>
+                                <varlistentry>
+                                    <term>SINGLE PLANE</term>
+                                    <listitem>
+                                        <para xml:id="para_c67afe3c-aef9-4ab5-9ae8-61aef9fe80b9">Image is a single plane acquisition</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>BIPLANE</term>
+                                    <listitem>
+                                        <para xml:id="para_6e9a8a70-97d0-4452-bdb1-4de4e197312d">Image is part of a Bi-plane acquisition</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>UNDEFINED</term>
+                                    <listitem>
+                                        <para xml:id="para_caf7dff5-a4f8-4efe-80ee-de88a79d2d14">Image is created by using data from one or two planes (e.g., reconstructed projection). Shall only be used when Image Type (0008,0008) Value 1 equals DERIVED.</para>
+                                    </listitem>
+                                </varlistentry>
+                            </variablelist>
+                        </section>
+                    </section>
+                </section>
+                <section label="C.8.19.3" status="4" xml:id="sect_C.8.19.3">
+                    <title>XA/XRF Acquisition Module</title>
+                    <para xml:id="para_64655162-ace1-4efb-b3e0-82787e51b675">
+                        <xref linkend="table_C.8.19.3-1" xrefstyle="select: label"/> specifies the Attributes of the XA/XRF Acquisition Module.</para>
+                    <table frame="box" label="C.8.19.3-1" rules="all" xml:id="table_C.8.19.3-1">
+                        <caption>XA/XRF Acquisition Module Attributes</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_ca1496ab-4211-4d20-a01d-54d044f7a4d5">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_61ce4780-5d54-4b83-a62b-9a3df3a14042">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_5fd6e663-3a96-4e67-ae30-a7a47e334a87">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_3112fa19-1474-44e8-95ae-ba6d66628dba">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_67b4fd16-4f94-47e9-8ff4-1af8341f2e9a">KVP</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_2c10c8cc-0b36-4166-b406-7b1fa0ba9894">(0018,0060)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_403040bc-19ee-4d0b-9225-c67edded0f20">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_1090d600-f31a-476f-a72a-7f411cdba7f1">Average of the peak kilo voltage outputs of the X-Ray generator used for all frames.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_d4da77c9-08c0-40d0-84e9-0f40fe1b1a3e">Radiation Setting</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e06f4642-aa4b-4722-8daf-ff4c8a2ee3d1">(0018,1155)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_681ab876-df26-4981-8f3e-6bf0274ef9f1">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_a8358915-1b2f-4102-9dab-f14d22263bdb">Identify the general level of X-Ray dose exposure.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>SC</term>
+                                            <listitem>
+                                                <para xml:id="para_6f970b17-8f01-4826-92e3-bb65fe35ca4a">low dose exposure generally corresponding to fluoroscopic settings (e.g., preparation for diagnostic quality image acquisition)</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>GR</term>
+                                            <listitem>
+                                                <para xml:id="para_4323d156-1e13-4cac-b478-3905a612ae34">high dose for diagnostic quality image acquisition (also called digital spot or cine)</para>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_72af94cf-ddf1-4a51-9da9-9f132eb0e102">X-Ray Tube Current in mA</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_c93feec6-e32e-4a79-8f4c-fcf58f2144e6">(0018,9330)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_aabfc97c-58ff-4686-82bf-d9b57ea32baa">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_566ccb79-4485-4206-8b10-22167cf53d7a">Average of the nominal X-Ray tube currents in milliamperes for all frames.</para>
+                                    <para xml:id="para_f26a409e-89bd-4bf5-88db-75781a2ad7bf">Required if Exposure in mAs (0018,9332) is not present. May be present otherwise.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_cc8a697f-ca68-4a81-a924-31187722497c">Exposure Time in ms</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_89e24a4e-df04-4a76-b3c5-fe69f6b793ff">(0018,9328)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_63504f0c-5291-4ee4-b2ee-21bb4df5f8f5">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_a342b1a5-33d8-4deb-9561-6611f206b736">Duration of X-Ray exposure in milliseconds. See <xref linkend="sect_C.8.7.2.1.1" xrefstyle="select: label"/>.</para>
+                                    <para xml:id="para_979117b5-5a82-47ba-8c82-16093a8d6809">Required if Exposure in mAs (0018,9332) is not present. May be present otherwise.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7de727c8-f933-4a5a-a9af-5e64a591f9a8">Exposure in mAs</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_297e3ef8-d3a4-4c7c-ba81-6ef620ef1052">(0018,9332)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e39f08db-0950-4734-9db2-4dcedd4efc77">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_6077a2a2-775e-4f8c-ad8c-50d72c41b790">The exposure expressed in milliampereseconds, for example calculated from Exposure Time and X-Ray Tube Current.</para>
+                                    <para xml:id="para_f70f557b-a571-48d8-9d2b-aa45ee8acd59">Required if either Exposure Time in ms (0018,9328) or X-Ray Tube Current in mA (0018,9330) are not present. May be present otherwise.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_1433e38d-0c49-48e5-bf5f-90c787e12ca9">Average Pulse Width</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_9f4a6b98-0efa-43f9-98c1-326f50b47ef3">(0018,1154)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_3e17ba92-03fe-4815-91f5-10b8adf5f33b">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_a3286c7c-0800-4059-a836-6736c9c00cc4">Average width of X-Ray pulse in msec.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_99c51e5b-54b6-4f7f-94f9-2ebd9eb9316f">Acquisition Duration</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_63fda85d-a16c-4ae1-b0a4-9063c099a5e6">(0018,9073)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_49073a24-0caa-48fa-bb4a-8cbfd376e060">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_862a7257-6fbe-4884-97c6-3e5104fb33a3">The time in seconds needed for the complete acquisition.</para>
+                                    <para xml:id="para_86c9b146-acd2-41e4-a011-c3a506dfd235">See <xref linkend="sect_C.7.6.16.2.2.1" xrefstyle="select: label"/> for further explanation</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_28f4592a-970b-45e0-b57e-bf28895ba62b">Radiation Mode</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_0dbf913c-7526-4fb0-accb-6cb7ef9ecb81">(0018,115A)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_80ad2eaf-c0fc-4246-93b1-ba89faa7bc10">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_881039f8-2da3-402c-9a09-59107c134b46">Specifies X-Ray radiation mode.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>CONTINUOUS</term>
+                                            <listitem>
+                                                <para xml:id="para_ec787b6f-054e-429d-84dd-9e5569c554ca"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>PULSED</term>
+                                            <listitem>
+                                                <para xml:id="para_10ca528c-a061-422c-900f-602ecc822f6a"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_89db3057-a1b9-49fe-9eb1-bbc6e87f3656">Focal Spot(s)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_83c155a3-4cef-4c77-b955-cce77d006667">(0018,1190)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_6605ce5f-92ec-448f-819a-70ce2ef2df63">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_995a14b6-3b52-45ca-8ead-acf50fe9683f">Nominal focal spot size in mm used to acquire this image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_7239cf1e-8aa4-440a-932b-60951e1a4fc6">Anode Target Material</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d076b6eb-45cc-4780-91bc-fee1aa089878">(0018,1191)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d5f9069c-57b7-49ed-b224-9a693a2d2b38">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_41b9b3e1-5aa8-42d8-925b-aa1de0cc7bbf">The primary material in the anode of the X-Ray source.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>TUNGSTEN</term>
+                                            <listitem>
+                                                <para xml:id="para_34efd45d-b8a4-4a51-b50c-1a6b9f10eda2"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>MOLYBDENUM</term>
+                                            <listitem>
+                                                <para xml:id="para_86fa149d-6472-46e1-bc22-13911d4ecc13"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>RHODIUM</term>
+                                            <listitem>
+                                                <para xml:id="para_a4b8990b-1093-41cf-93a3-85fda318a496"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_b4349c81-cda5-4b84-b302-6b1be2529f34">Rectification Type</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_6352abbe-0da6-4603-a1f8-6840166c6f70">(0018,1156)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_3ea98f8d-3ee9-41ba-877c-65018663f1e6">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_f8563224-61b7-4a32-997c-20f9de857b4f">Type of rectification used in the X-Ray generator.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>SINGLE PHASE</term>
+                                            <listitem>
+                                                <para xml:id="para_5bfd72d1-f355-4dca-aa31-df74e12eb623"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>THREE PHASE</term>
+                                            <listitem>
+                                                <para xml:id="para_829c1ff0-b1b9-4f1a-94bb-2387d0359479"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>CONST POTENTIAL</term>
+                                            <listitem>
+                                                <para xml:id="para_ca6c5be7-6cd2-4546-ad18-2275791a1865"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_f9414c3d-e2f7-4af0-93a0-9118e80e0de5">X-Ray Receptor Type</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_576450d4-07a2-459e-8b08-b222080f238c">(0018,9420)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_435102fd-fb1c-4236-a276-9826b8218ed9">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_956427ce-2596-4799-ae28-c6056926fbcc">Identifies with type of X-Ray receptor is used.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>IMG_INTENSIFIER</term>
+                                            <listitem>
+                                                <para xml:id="para_18c99bf4-e446-4272-ac72-668157c7fef8"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>DIGITAL_DETECTOR</term>
+                                            <listitem>
+                                                <para xml:id="para_01ebf0ba-7c4a-4e1b-a2dc-0e75806bae4b"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_9bd2d58c-89c2-47c5-bf3a-a1d7ed6b105d">Distance Receptor Plane to Detector Housing</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_c9f1b722-712c-4d63-9cf6-e58440c4d23a">(0018,9426)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_7f6e516e-7004-4452-b738-0bd9131b0a5d">2</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_dc39424c-026c-4b5d-b009-ef69ec0005ff">Distance in mm between the receptor plane and the detector housing. The direction of the distance is positive from receptor plane to X-Ray source.</para>
+                                    <note>
+                                        <orderedlist numeration="arabic">
+                                            <listitem>
+                                                <para xml:id="para_d2eda390-8fee-4332-91eb-913e30a993ca">A negative value is allowed in the case of an image intensifier the receptor plane can be a virtual plane located outside the detector housing depending the magnification factor of the intensifier. A negative value is not applicable for the digital detector.</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_eb4e7002-1ec9-4914-8975-93e3b15df6c2">Used to calculate the pixel size of the plane in the patient when markers are used, and they are placed on the detector housing.</para>
+                                            </listitem>
+                                        </orderedlist>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_3c2ea302-d6d2-49ec-bcf5-cc7aeddf5c80">Positioner Type</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_73d8cf8f-e572-40cb-bb26-3d0bea531e60">(0018,1508)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_e8bdb609-d57b-4dae-83dd-6d0e28a99062">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>CARM</term>
+                                            <listitem>
+                                                <para xml:id="para_c19833ed-1540-40eb-9059-3d7805d3883d"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>COLUMN</term>
+                                            <listitem>
+                                                <para xml:id="para_77b31e5e-7ff0-4f29-8b7e-54d9a6382d66"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <note>
+                                        <orderedlist numeration="arabic">
+                                            <listitem>
+                                                <para xml:id="para_f0fbc721-303f-4227-a2d7-d71551f3c027">The term CARM can apply to any positioner with 2 degrees of freedom of rotation of the X-Ray beam about the Imaging Subject.</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_d4f57e72-49f3-4e50-898e-440ab2f586fc">The term COLUMN can apply to any positioner with 1 degree of freedom of rotation of the X-Ray beam about the Imaging Subject.</para>
+                                            </listitem>
+                                        </orderedlist>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_35fad39c-d275-4d76-aa0c-c08e2fb2183b">C-arm Positioner Tabletop Relationship</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_1e354f7c-d9b7-451f-8238-d7e9c903b72d">(0018,9474)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_9e6cd035-2902-4e12-ace3-a7489fd362b9">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_59aab369-a93f-4992-b841-165434820641">Describes for C-arm positioner type systems if positioner and tabletop has the same geometrical reference system.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>YES</term>
+                                            <listitem>
+                                                <para xml:id="para_ff533757-e1a9-4110-a547-139fb6d5a4ce"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>NO</term>
+                                            <listitem>
+                                                <para xml:id="para_0a0f7a5b-55d5-4702-8e21-bef432f7833b"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <note>
+                                        <para xml:id="para_48c4bb90-f336-4e97-aa64-337d53b9324a">The value NO is intended for mobile systems where there is no table fixed to the system</para>
+                                    </note>
+                                    <para xml:id="para_0dcf5ff2-2c74-4ab1-84d9-2c87197fba7d">Required if Positioner Type (0018,1508) equals CARM.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_5d61b5de-f355-4f8f-a534-e9672c40faf2">Acquired Image Area Dose Product</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_41bd4cc6-18a9-4a1a-8886-26b80eb04954">(0018,9473)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_1fb89592-ed81-4eda-a67d-ec7e3ff49664">2</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_5d7a66bc-5424-489b-884a-bc357a9994d7">X-Ray dose, measured in dGy*cm*cm, to which the patient was exposed for the acquisition of this image only.</para>
+                                    <note>
+                                        <orderedlist numeration="arabic">
+                                            <listitem>
+                                                <para xml:id="para_18703bdf-413a-4f30-a412-dd40ae21ebd9">The sum of the Image Area Dose Product of all images of a Series or a Study may not result in the actual area dose product to which the patient was exposed.</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_b811b291-7eda-478f-b56f-642e73b9c45c">This may be an estimated value based on assumptions about the patient's body size and habitus.</para>
+                                            </listitem>
+                                        </orderedlist>
+                                    </note>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section label="C.8.19.4" status="4" xml:id="sect_C.8.19.4">
+                    <title>X-Ray Image Intensifier Module</title>
+                    <para xml:id="para_8c1b447f-3b2d-4507-8d8a-327b6019d65c">
+                        <xref linkend="table_C.8.19.4-1" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Image Intensifier Module.</para>
+                    <table frame="box" label="C.8.19.4-1" rules="all" xml:id="table_C.8.19.4-1">
+                        <caption>X-Ray Image Intensifier Module Attributes</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b2d8373c-0288-412b-acce-b1fcbb482faa">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d0a3dcaa-1f13-44a5-b73d-1bdda197a94b">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_d98e3907-e072-4bad-af5d-5b22494bfb2b">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_727051f4-f235-4d82-be5f-827d5fc1d846">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_bdff4d5c-1544-4852-8f0b-9574ba26a448">Intensifier Size</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b1f57928-f5a1-4c1c-8a38-a6f45c30fe1f">(0018,1162)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b9b4f6b1-38b1-43a9-92f0-1792b16b2367">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_14675c3f-24ca-4a68-bb1f-5383ca3bd870">Physical diameter of the maximum active area X-Ray intensifier in mm.</para>
+                                    <note>
+                                        <para xml:id="para_fb075dd8-722b-497a-970a-3e942fac1fa7">This Attribute does not specify the field of view. The Attribute Field of View Dimension(s) in Float (0018,9461) is intended for this value.</para>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_3f347d9e-efc4-4886-88e2-7a14f970d220">Intensifier Active Shape</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_7615df29-b09b-4c0a-b262-38780584dd64">(0018,9427)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_1f8664e7-3b4d-4a35-8edd-5d3126a3e4dd">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_0d2372a1-04da-49ee-974e-c2c06f0c6b8a">Shape of the active area used for acquiring this image.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>RECTANGLE</term>
+                                            <listitem>
+                                                <para xml:id="para_d0b8de6f-58ee-465c-8fa9-a0dba0d47cdc"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>ROUND</term>
+                                            <listitem>
+                                                <para xml:id="para_272f5d22-ba41-4a11-a62f-f0a36da0f483"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>HEXAGONAL</term>
+                                            <listitem>
+                                                <para xml:id="para_3ce6dd75-1ab2-498f-b9ba-97c553de9cea"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <note>
+                                        <para xml:id="para_42b3f213-d339-42c7-9710-a14c198c8a28">This may be different from the Field of View Shape (0018,1147), and should not be assumed to describe the stored image.</para>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_6fc1d057-115a-41be-86c7-687cf05d5dc7">Intensifier Active Dimension(s)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f503d32b-fa69-451b-8fd7-788c61bf3aa7">(0018,9428)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_09f8355e-25cb-4c8b-9798-04a98d499a4f">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_eb1550a5-423b-4fb3-9789-b732cc48e807">Dimensions in mm of the active area used for acquiring this image.</para>
+                                    <para xml:id="para_6646f4f3-98e2-4534-96ca-c9343e4f1542">If Intensifier Active Shape (0018,9427) is:</para>
+                                    <para xml:id="para_4e59b960-0d7c-4bcb-aa42-77042af67105">RECTANGLE: row dimension followed by column.</para>
+                                    <para xml:id="para_eb19dec7-c7fa-4468-be06-71ff1f4c6e2e">ROUND: diameter.</para>
+                                    <para xml:id="para_205f0a21-f2c5-47c1-8431-fc828f9784dd">HEXAGONAL: diameter of the circle circumscribing the hexagon.</para>
+                                    <note>
+                                        <para xml:id="para_a46bddb9-877c-4a54-abe1-b628dc6e9975">This may be different from the Field of View Dimension(s) in Float (0018,9461), and should not be assumed to describe the stored image.</para>
+                                    </note>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section label="C.8.19.5" status="4" xml:id="sect_C.8.19.5">
+                    <title>X-Ray Detector Module</title>
+                    <para xml:id="para_7cb3705f-37e1-47e6-969f-65d0a0e68533">
+                        <xref linkend="table_C.8.19.5-1" xrefstyle="select: label"/> contains IOD Attributes that describe an X-Ray detector.</para>
+                    <table frame="box" label="C.8.19.5-1" rules="all" xml:id="table_C.8.19.5-1">
+                        <caption>X-Ray Detector Module Attributes</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_2bc4e794-04ed-4734-b957-e162a3c21bf8">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b79308a5-cdc5-48ff-ad47-700dae775253">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_44aaed97-f357-4eeb-be8f-9084b94591ba">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_5a1270d2-4abf-408a-8c3f-39ea0031830f">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="3" rowspan="1">
+                                    <para xml:id="para_f16b677c-05cd-46c9-b069-9c442f16dacb">
+                                        <emphasis role="italic">Include <xref linkend="table_C.8-71b" xrefstyle="select: label quotedtitle"/>
+                                        </emphasis>
+                                    </para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_59bdb1b9-5137-4d8a-afa9-c6e647811889"/>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_b6be3271-78bb-4997-ad32-aeb85247784a">Physical Detector Size</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_497667c3-3729-46e0-8a64-c9bba68ef09c">(0018,9429)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_044b6289-360d-48d6-a81f-308a54afa493">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_4ba14a97-9c78-4da7-b498-2414b7a02010">Dimensions of the physical detector measured in mm as a row size followed by a column size.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_6daff4a9-95e3-432e-97e2-11681b0c6191">Position of Isocenter Projection</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_366eac99-98cb-4557-826d-409e301ed370">(0018,9430)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_7cd80969-7512-4c10-9f35-03b1f1e535ea">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_bfb8564b-d2e8-47ce-af78-38f25906df54">Position of the Isocenter projection on the detector plane measured in fractional physical detector elements as a distance along the column direction followed by a distance along the row direction from the center of the TLHC detector element of a rectangle circumscribing the physical detector area.</para>
+                                    <para xml:id="para_3a1c35a8-bf5b-41d8-96c4-ead22d11ac1d">Required if Isocenter Reference System Sequence (0018,9462) is present.</para>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section label="C.8.19.6" status="4" xml:id="sect_C.8.19.6">
+                    <title>Enhanced XA/XRF Image Functional Group Macros</title>
+                    <para xml:id="para_ef7b2b5b-2190-4fd4-ae1b-e5ec22a4623a">The following sections contain Functional Group Macros specific to the Enhanced XA Image IOD.</para>
+                    <note>
+                        <para xml:id="para_b0eed3b2-26dd-42ea-8699-418d1c945ee6">The Attribute descriptions in the Functional Group Macros are written as if they were applicable to a single frame (i.e., the Macro is part of the Per-frame Functional Groups Sequence). If an Attribute is applicable to all frames (i.e., the Macro is part of the Shared Functional Groups Sequence) the phrase "this frame" in the Attribute description shall be interpreted to mean " for all frames".".</para>
+                    </note>
+                    <section label="C.8.19.6.1" status="5" xml:id="sect_C.8.19.6.1">
+                        <title>X-Ray Frame Characteristics Macro</title>
+                        <para xml:id="para_40a517b4-d387-439b-9e6b-404b74482ebd">
+                            <xref linkend="table_C.8.19.6-1" xrefstyle="select: label"/> specifies the Attributes of the XA/XRF Frame Characteristics Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-1" rules="all" xml:id="table_C.8.19.6-1">
+                            <caption>X-Ray Frame Characteristics Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_0f6791d6-15d7-4a3c-8aa5-f3c005d41d55">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_632ed041-442b-40af-bd49-eabaff9d0ceb">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_592de114-5d02-427c-a072-c6e1ea5c93e9">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_616cc002-88d2-43a2-940e-fc1563e77220">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_b5049897-8e37-405d-a498-4f3e42887459">XA/XRF Frame Characteristics Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d1539e0d-1817-4a7f-a0a2-39c3cdcb0f3a">(0018,9412)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_bfaec9af-56bc-4a5a-a317-ebae8cb55bd2">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_6c493a24-754c-4bc5-bd24-a7a4f7f4d58d">A Sequence that describes general characteristics of this frame.</para>
+                                        <para xml:id="para_333da722-72dc-4153-9540-668a96ee5677">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1175d51c-27b0-4005-a12c-2261a846143a">&gt;Derivation Description</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_dec15679-54c7-4f29-9449-4c34fd287aec">(0008,2111)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2bada612-65ea-48f8-a616-96c191eeb3ba">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_56be729e-9fad-419b-8caf-23a4d570e0dd">A text description of how this frame was derived.</para>
+                                        <para xml:id="para_4a88bcf2-297c-4a18-b5ef-10519cbb4e45">See <xref linkend="sect_C.8.7.1.1.5" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_6850dc9c-074f-4006-b99c-91b850282fa4">&gt;Derivation Code Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3280ee1e-7edc-4f62-bc3c-ddf06c102b83">(0008,9215)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9396de7d-6221-4bea-b3d3-8c397c749d0b">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_91317fbc-d9fc-4154-9b4b-8adeb3b5dd91">A coded description of how this frame was derived. See <xref linkend="sect_C.12.4.1.1" xrefstyle="select: label"/> for further explanation.</para>
+                                        <para xml:id="para_5c184d45-e467-40c9-847a-5b37f4ed08be">One or more Items are permitted in this Sequence.</para>
+                                        <para xml:id="para_41da1fc5-96c6-4dc4-8d5a-24c4cbb61c42">More than one Item indicates that successive derivation steps have been applied.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="3" rowspan="1">
+                                        <para xml:id="para_28e1277b-e45b-496e-b45b-906c7cdeba93">
+                                            <emphasis role="italic">&gt;&gt;Include <xref linkend="table_8.8-1" xrefstyle="select: label quotedtitle"/>
+                                            </emphasis>
+                                        </para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_2114c598-fdeb-4440-8edc-34ff1fde9d0a">
+                                            <emphasis role="italic">D<olink targetdoc="PS3.16" targetptr="sect_CID_7203" xrefstyle="select: labelnumber quotedtitle"/>.</emphasis>
+                                        </para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_9bb9357e-7291-497a-96c8-65a8997399c1">&gt;Acquisition Device Processing Description</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9e922e3e-8aa4-4da8-9f34-a670e2df9927">(0018,1400)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c31e962f-d8e1-4572-92ad-8424612bad13">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_4647befa-36fa-4872-8c21-a9d7bf54c5c1">Indicates any visual processing performed on the frame prior to exchange.</para>
+                                        <para xml:id="para_629ae973-6846-4a19-b555-e77fe69d8b3e">See <xref linkend="sect_C.8.7.1.1.3" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_07ea918e-9e33-4364-a928-902bb1242ae5">&gt;Acquisition Device Processing Code</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d38bedf5-efd3-42bc-9b6c-13876880ea13">(0018,1401)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a058e3ef-0623-4de3-b601-8860e942b6cd">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_4297df52-a2d8-4bca-ba80-e7c8c12153ed">Code representing the device-specific processing associated with the frame (e.g., Organ Filtering code)</para>
+                                        <note>
+                                            <para xml:id="para_f9b551b3-b102-4f9d-92db-9c41266476c2">This Code is manufacturer specific but provides useful annotation information to the knowledgeable observer.</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                    <section label="C.8.19.6.2" status="5" xml:id="sect_C.8.19.6.2">
+                        <title>X-Ray Field of View Macro</title>
+                        <para xml:id="para_1fe814c4-3d65-4f86-a7aa-f542cb48e391">
+                            <xref linkend="table_C.8.19.6-2" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Field of View Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-2" rules="all" xml:id="table_C.8.19.6-2">
+                            <caption>X-Ray Field of View Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e8a405e3-7510-40dd-aac3-326fe0e616a7">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_6c7e823b-aa9b-423c-b31f-1ff60ec463b5">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_83b81d15-dddd-456b-8b5b-d4437a54b97d">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3517ef74-ba70-4457-a854-b3ea24bda456">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_93d3797a-f474-46d1-8b81-4e849788b003">Field of View Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_51edd68b-5ff3-4d55-a422-4196e0fb2385">(0018,9432)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f42fda08-a356-463b-8ede-c2f38360b8dd">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_126ff002-84da-4839-a86a-ea9ee942d628">Sequence containing the field of view for this frame.</para>
+                                        <para xml:id="para_ad3c8d36-2bdd-4065-bb02-ae94613fab3f">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_db094aa8-5154-4313-af33-e965ccbc6949">&gt;Field of View Shape</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_772c13a7-a97e-4875-918a-a5b34deae8b2">(0018,1147)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_84f7ed17-f4e9-4347-9550-08980c99e00c">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_a422d91b-12ce-4ce7-ad2f-ad0c24a96d4a">Shape of the Field of View, that is the image pixels stored in Pixel Data (7FE0,0010).</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>RECTANGLE</term>
+                                                <listitem>
+                                                    <para xml:id="para_b37d96ab-7c12-428f-86f4-68af118c9e47"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>ROUND</term>
+                                                <listitem>
+                                                    <para xml:id="para_63a5531a-857a-4599-8baa-4bc558c02dff"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>HEXAGONAL</term>
+                                                <listitem>
+                                                    <para xml:id="para_0b4b094b-ce38-4014-95ea-eb6c2320494b"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_3e7c4fbc-4e75-49f7-a87f-95600622f4fd">&gt;Field of View Dimension(s) in Float</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_37169ad4-8263-4d00-bafd-cb892744d75e">(0018,9461)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_76600a6b-a365-4a78-9307-9e8d2a6dba5f">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_842544ce-86c8-4c78-ab88-4f196166982d">Dimensions in mm of the Field of View, that is the image pixels stored in Pixel Data (7FE0,0010). If Field of View Shape (0018,1147) is:</para>
+                                        <para xml:id="para_f47b5ee4-f232-4446-a1f7-1f233bc932be">RECTANGLE: row dimension followed by column.</para>
+                                        <para xml:id="para_3c67dd8b-9927-4767-9932-5d1b12db9324">ROUND: diameter.</para>
+                                        <para xml:id="para_f418bd29-224a-403e-b3e0-37a51ff8935c">HEXAGONAL: diameter of the circle circumscribing the hexagon.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_f208d125-b308-4483-8920-03938ec1ce54">&gt;Field of View Origin</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_41524b43-f87b-405c-9dfb-4d3db7e97728">(0018,7030)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_58e0ffd8-c2a9-4f43-b2a7-a825a40bc619">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_de3ba408-f307-4c57-9953-943b225fa228">Offset of the TLHC of a rectangle circumscribing the Field of View, i.e., the image pixels stored in Pixel Data (7FE0,0010) before rotation or flipping, from the TLHC of the physical detector area measured in physical detector pixels as a row offset followed by a column offset.</para>
+                                        <para xml:id="para_f15a0af9-57db-4469-a949-401921215fc7">See <xref linkend="sect_C.8.11.4.1.1" xrefstyle="select: label"/> for further explanation.</para>
+                                        <para xml:id="para_6e53b23b-c6ec-4c27-a49d-8204247f2dc1">Required if X-Ray Receptor Type (0018,9420) is present and equals DIGITAL_DETECTOR. May be present otherwise.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_ea65ed92-a2cc-4adc-be69-bdfc19455b29">&gt;Field of View Rotation</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c3d629c8-ae36-4f50-ba9f-9860ebb9c5b8">(0018,7032)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_cf5f8772-7927-41ef-90a8-640d6abf3b70">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d42371fa-e8a7-4e5d-9ad1-f934ea510c68">Clockwise rotation in degrees of Field of View, i.e., the image pixels stored in Pixel Data (7FE0,0010), relative to the physical detector.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>270</term>
+                                                <listitem>
+                                                    <para xml:id="para_53f00dfe-bb11-47e8-856c-44410cbf1408"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>180</term>
+                                                <listitem>
+                                                    <para xml:id="para_25e4440a-9aa7-4e83-8bbc-e19791f0f7b0"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>90</term>
+                                                <listitem>
+                                                    <para xml:id="para_739e402b-1553-4fe6-8d4c-0ccbe341ee66"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>0</term>
+                                                <listitem>
+                                                    <para xml:id="para_ed190606-a7a3-4b0f-b9f2-ef5c47c72a39"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                        <para xml:id="para_7641d3b3-ff72-406d-ada7-c0b9e877a09a">See <xref linkend="sect_C.8.11.4.1.1" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_95a5037a-a7b7-48df-a681-acdb92d3d690">&gt;Field of View Horizontal Flip</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_8ffbd5c8-1dc6-4598-ba8c-8b492806c575">(0018,7034)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7ba736a7-73cf-4810-a3c2-0569ce4a1d0d">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_b70ecc6b-f7e4-45fa-ad25-62428e93b745">Whether or not a horizontal flip has been applied to the Field of View, i.e., the image pixels stored in Pixel Data (7FE0,0010), after rotation relative to the physical detector as described in Field of View Rotation (0018,7032).</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>NO</term>
+                                                <listitem>
+                                                    <para xml:id="para_0494a19c-b91d-4eb4-a9fb-3bafec4bb75e"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>YES</term>
+                                                <listitem>
+                                                    <para xml:id="para_9db82fe2-2edb-4003-8423-a252be9a9310"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                        <para xml:id="para_4a2937eb-2d5c-4a43-b626-0af2205c225e">See <xref linkend="sect_C.8.11.4.1.1" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c07a9932-c63b-4804-84ba-2ab3b767a8a1">&gt;Field of View Description</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a207ddf0-05f8-4b42-aa0f-999b4445947a">(0018,9433)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b36e9dbb-abfe-4e40-8f42-5af349eb3d8c">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_8e9d491d-7e7c-4f49-b27e-f509ea8b1d15">Manufacturer defined description of the field of view selected during acquisition.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                    <section label="C.8.19.6.3" status="5" xml:id="sect_C.8.19.6.3">
+                        <title>X-Ray Exposure Control Sensing Regions Macro</title>
+                        <para xml:id="para_9ec4128f-8dfd-4e44-9885-892b8b34e1a0">
+                            <xref linkend="table_C.8.19.6-3" xrefstyle="select: label"/> specifies the Attributes that describe the region targeted as area where the X-Ray dose value is estimated.</para>
+                        <table frame="box" label="C.8.19.6-3" rules="all" xml:id="table_C.8.19.6-3">
+                            <caption>X-Ray Exposure Control Sensing Regions Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f0a193cc-5050-4731-b622-ea7de9545647">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9aa33d7f-f536-4d69-a0c1-1c9992c70bf5">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5e9b1b07-25a7-4644-b073-7d495017b41e">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9d60fd13-e885-4b58-a08a-9b6c90240412">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_ecba076c-3ebe-4225-a4dd-3377a0f16970">Exposure Control Sensing Regions Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c7d99682-fac7-43b9-ac60-9ed23b0294d6">(0018,9434)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_0c39b66a-5aa7-4748-b43d-e9ae13af2773">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c21fd05e-b6e6-4bc0-be10-78c5b6384d12">Sequence containing the Exposure Control Sensing Region for this frame.</para>
+                                        <para xml:id="para_b0f6adc2-155d-458f-8b02-5da85a21f7ed">One or more Items shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_42df0974-31ea-470b-a231-9985d2436d37">&gt;Exposure Control Sensing Region Shape</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_38acc953-c901-420b-89f3-17f34f196897">(0018,9435)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_aa338ed4-dc6b-4dd4-8862-3ddad2cc4a97">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_08054ab5-3fd6-4db0-8c87-1f7e114d0321">Shape of the Exposure Control Sensing Region.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>RECTANGULAR</term>
+                                                <listitem>
+                                                    <para xml:id="para_d6a9b074-ddf6-4f81-bcd6-6b2a4179809a"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>CIRCULAR</term>
+                                                <listitem>
+                                                    <para xml:id="para_43d3a8a7-d0b7-4659-83e1-475a9b909f88"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>POLYGONAL</term>
+                                                <listitem>
+                                                    <para xml:id="para_4b314ee9-67f9-4acc-a3e8-ca0ee9f8cdb3"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_891b73cc-04a4-43c7-ac44-9962b436a9d0">&gt;Exposure Control Sensing Region Left Vertical Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2739e5c6-a9e0-4e80-aa96-6f3d06615a8e">(0018,9436)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9ac25c53-2caa-4a86-a0fd-09923732bb13">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_ec2ac20b-084c-4159-87d2-8940f919e82a">Required if Exposure Control Sensing Region Shape (0018,9435) is RECTANGULAR. Location of the left edge of the rectangular Exposure Control Sensing Region expressed as effective pixel column. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_0edbd7c2-5f9c-43eb-b6a1-7eba53516dbc">&gt;Exposure Control Sensing Region Right Vertical Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_811b4543-31bf-4a65-9719-946894724adc">(0018,9437)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9b31ee3a-7616-4e24-bf69-f734af1712ed">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_02c65b72-dfe0-432e-b12c-1e17fd8593f1">Required if Exposure Control Sensing Region Shape (0018,9435) is RECTANGULAR. Location of the right edge of the rectangular Exposure Control Sensing Region expressed as effective pixel column. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_39c9b8e8-6aa3-4f3c-be39-31ecaa6a7869">&gt;Exposure Control Sensing Region Upper Horizontal Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5c80d6f7-a619-4a5e-ad32-29ad670ae5a8">(0018,9438)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c50bb25e-a1a6-4896-8dbb-ec6f012b6926">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_aad2ec3b-74df-42ca-b017-c3667cc205ec">Required if Exposure Control Sensing Region Shape (0018,9435) is RECTANGULAR. Location of the upper edge of the rectangular Exposure Control Sensing Region expressed as effective pixel row. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_63dc9b01-8436-4cf6-85df-7003d53869b9">&gt;Exposure Control Sensing Region Lower Horizontal Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_43745c2c-70c1-4a25-b6ac-31bb8853b506">(0018,9439)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9e22c1ee-0f0c-42ed-be17-055b5c499197">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_edd760b7-97f7-4f84-aab3-e3e4ee605156">Required if Exposure Control Sensing Region Shape (0018,9435) is RECTANGULAR. Location of the lower edge of the rectangular Exposure Control Sensing Region expressed as effective pixel row. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_910ca157-173a-42f1-8b38-0a67f0951020">&gt;Center of Circular Exposure Control Sensing Region</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_45672aa5-f5eb-434a-8756-cef494b513b9">(0018,9440)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7bb8c14b-7340-4f58-bf6b-e55e0a519bbd">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_959a748c-91da-48f3-b182-8f4a1cce03d8">Required if Exposure Control Sensing Region Shape (0018,9435) is CIRCULAR. Location of the center of the circular Exposure Control Sensing Region expressed as effective pixel row and column. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_f0485c71-b0c5-4f78-a831-b1ae6f3ce5c7">&gt;Radius of Circular Exposure Control Sensing Region</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f97d46f8-bb43-4d5c-826d-2cdc1ef0882d">(0018,9441)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f00df737-d145-43ff-b1f6-e244526cd1b9">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c8d091a3-cbb4-4c33-9acf-af038fe1ce2f">Required if Exposure Control Sensing Region Shape (0018,9435) is CIRCULAR. Radius of the circular Exposure Control Sensing Region expressed as effective number of pixels along the row direction. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d81b1b0b-3a07-4e95-b4c7-9677edc465e0">&gt;Vertices of the Polygonal Exposure Control Sensing Region</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_82fbb55e-8e69-4b9c-9b96-665fc51e59b9">(0018,9442)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2296acb1-607f-4e63-a22e-67205cba4690">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_14800cf7-947c-417a-a292-01c6d47a3857">Required if Exposure Control Sensing Region Shape (0018,9435) is POLYGONAL.</para>
+                                        <para xml:id="para_1f644d15-9bf2-4222-bfd3-6f159ff7d6f0">Multiple Values where the first set of two values are:</para>
+                                        <para xml:id="para_2c963728-182a-433d-8ed5-66c8bcfdb292">row of the origin vertex;</para>
+                                        <para xml:id="para_245f0bca-280f-467a-a21b-84d520beca5a">column of the origin vertex.</para>
+                                        <para xml:id="para_b8f40071-7538-4ca9-b454-94d0870cd7ca">Two or more pairs of values follow and are the effective pixel row and column coordinates of the other vertices of the polygon Exposure Control Sensing Region. Polygon Exposure Control Sensing Regions are implicitly closed from the last vertex to the origin vertex and all edges shall be non-intersecting except at the vertices. See <xref linkend="sect_C.8.19.6.3.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.3.1" status="6" xml:id="sect_C.8.19.6.3.1">
+                            <title>X-Ray Exposure Control Sensing Regions Attributes</title>
+                            <para xml:id="para_9b89cf7b-a920-4a05-808f-adab83e04c1e">The Exposure Control Sensing Region Left Vertical Edge (0018,9436), Exposure Control Sensing Region Right Vertical Edge (0018,9437), Exposure Control Sensing Region Upper Horizontal Edge (0018,9438), Exposure Control Sensing Region Lower Horizontal Edge (0018,9439) and Center of Circular Exposure Control Sensing Region (0018,9440) may have a negative value when the point defined by the Attribute lies outside the left or upper border of the pixel data matrix. The top left pixel of the image has a pixel row and column value of 1.</para>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.4" status="5" xml:id="sect_C.8.19.6.4">
+                        <title>X-Ray Frame Pixel Data Properties Macro</title>
+                        <para xml:id="para_6b2d161f-4e57-45fa-ac0d-966ccf91a7b2">
+                            <xref linkend="table_C.8.19.6-4" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Frame Pixel Data Properties Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-4" rules="all" xml:id="table_C.8.19.6-4">
+                            <caption>X-Ray Frame Pixel Data Properties Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_98e0f020-bac4-4f64-8deb-fd4195a34951">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_bd9c4190-692a-4dea-8787-63275bd0f7db">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a4b9f7e7-1455-4c1e-aa9e-ffe300140c38">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3118f321-1b17-48f3-a5e5-9f11eabb031b">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_bdf7f046-81a8-4fdf-8da6-e39c28236680">Frame Pixel Data Properties Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_bfcf0f36-40e8-41c4-b655-2c6e08ff59f8">(0028,9443)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c83be70f-033e-4240-9509-25b8bc498967">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_68e8eac3-546a-4cba-8083-a92ef943629d">Sequence containing the pixel data properties for this frame.</para>
+                                        <para xml:id="para_4b4c0b74-acca-4ada-9fd4-bd880a3668f8">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_aec2593d-c929-47b9-b268-5b1367849aab">&gt;Frame Type</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7b1c0580-99a2-48e4-ad5c-8766386cd8fd">(0008,9007)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f94889fa-f9c8-4bf5-a265-d0900909a73a">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_fc7e3065-5cf4-4e2f-b227-3b16fe3b5421">Type of Frame. A multi-valued Attribute analogous to Image Type (0008,0008).</para>
+                                        <para xml:id="para_3e4a69ff-1e6c-4cb3-ab31-6cd69e9ff103">Enumerated Values and Defined Terms are the same as those for the values of Image Type (0008,0008).</para>
+                                        <para xml:id="para_46ea8621-1ca7-4aac-b0f7-5b4b3305383d">See <xref linkend="sect_C.8.19.2.1.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_dd5bbade-23c0-4b1c-8752-576c394eb683">&gt;Pixel Intensity Relationship</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_23eb0999-1ea8-487f-ac23-b1fb5c7b8734">(0028,1040)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9f694699-72fc-444d-8398-bd4ff853ce30">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_52ca9eaf-9043-4b4e-aab5-99ace26e5fba">The relationship between the Pixel and the X-Ray beam intensity. See <xref linkend="sect_C.8.19.6.4.1.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_0a1e50e1-cf82-4e88-b076-d9ba16d2a796">&gt;Pixel Intensity Relationship Sign</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_44504484-c46a-4a13-bf3e-9b36115eb5c7">(0028,1041)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c9120e69-bec1-4bd3-b2dc-f73eaec7e303">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_b4e22ffa-5ab9-43a0-8e2a-2e52289f1c7c">The sign of the relationship between the Pixel sample values stored in Pixel Data (7FE0,0010) and the X-Ray beam intensity.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>+1</term>
+                                                <listitem>
+                                                    <para xml:id="para_53931309-ab74-4e67-8066-e7b0b19b66d5">Lower pixel values correspond to less X-Ray beam intensity</para>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>-1</term>
+                                                <listitem>
+                                                    <para xml:id="para_44931a0f-f13b-4d9a-97ea-fe0e2884cf1a">Higher pixel values correspond to less X-Ray beam intensity</para>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                        <para xml:id="para_8e97ea8d-5a52-4666-850a-b3a707227948">See <xref linkend="sect_C.8.11.3.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_a0b5a2ce-fea3-407f-9ffa-cc6d4af2a6d4">&gt;Imager Pixel Spacing</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d4f21e3a-fe31-43d3-9b89-ea0b0948871f">(0018,1164)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9bedcb69-24f0-41ee-81e0-3134cc1e757d">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_a8bac933-7987-472a-a6cb-96558f1a3a4b">Physical distance measured at the receptor plane of the detector between the centers of each pixel specified by a numeric pair - row spacing value (delimiter) column spacing value in mm. See <xref linkend="sect_10.7.1.3" xrefstyle="select: label"/> for further explanation of the value order.</para>
+                                        <para xml:id="para_13cff92b-820d-4c5d-8e06-87be1c0bfc34">The value of this Attribute shall never be adjusted to account for calibration against an object of known size; Pixel Spacing (0028,0030) is specified for that purpose.</para>
+                                        <para xml:id="para_880af985-4bea-4662-9b37-9a46d9fcfda1">It is only allowed to be adjusted to compensate for the change of the Field of View Dimension(s) in Float (0018,9461) Attribute. See <xref linkend="sect_C.8.19.6.4.1.2" xrefstyle="select: label"/>
+                                        </para>
+                                        <para xml:id="para_06b6bc86-caa6-44ca-9f64-2fff2645646d">Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise.</para>
+                                        <note>
+                                            <para xml:id="para_19c2029c-6213-413b-a2aa-873494434afc">These values are the actual pixel spacing distances of the stored pixel values of an image.</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d942153a-3090-4177-bc50-86b2a33f2a98">&gt;Pixel Data Area Origin Relative To FOV</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_12955980-c699-45df-bde1-c19a0120f82d">(0018,7036)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ba99f7b4-0b1c-4187-9284-07b759580fd3">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_764105ae-d32f-480f-8a78-1b639a556876">Offset of the TLHC of the image stored in Pixel Data (7FE0,0010) from the TLHC of the Field Of View Area after FOV rotation and Flip. It is measured in image stored pixels as a row offset followed by a column offset.</para>
+                                        <note>
+                                            <para xml:id="para_61433c57-9333-4bfb-96af-f8071d77cbba">Due to the differences in image stored pixel and detector element spacing, one may expect this Attribute to have non-integer values.</para>
+                                        </note>
+                                        <para xml:id="para_67dcaa50-fbe4-4a6d-b386-c871696bb402">See <xref linkend="sect_C.8.19.6.4.1.3" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d0fd4e57-6f93-42fc-9fac-16480c883337">&gt;Pixel Data Area Rotation Angle Relative To FOV</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e9828b4f-8a22-42a9-9235-504bde764f52">(0018,7038)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_aefc78c1-5238-4a4c-8ab0-3cc89d682f97">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_3c7ffb1c-6a02-48e5-9959-2307c704039c">Angle clockwise of the row direction of the image stored in Pixel Data (7FE0,0010) relative to the row direction of the Field Of View Area after FOV rotation and Flip. It is measured in degrees.</para>
+                                        <para xml:id="para_06fadeb7-c53c-460b-8b1a-e630fab1fbe3">See <xref linkend="sect_C.8.19.6.4.1.3" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_df16f0ad-df4b-4025-8c04-0ac9fdf09a1f">&gt;Geometrical Properties</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a9e46d33-66dc-4193-a41d-8cb05db06cf3">(0028,9444)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5f863dec-e406-4429-80f7-1a107662e644">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_9a9ffaa9-e748-45ec-95eb-b956eae2c9e9">Geometrical characteristics of the pixel data to indicate whether pixel spacing is uniform for all pixels or not.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>UNIFORM</term>
+                                                <listitem>
+                                                    <para xml:id="para_f6bd30cf-6dee-4f0d-b653-5f1fd72800f0"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>NON_UNIFORM</term>
+                                                <listitem>
+                                                    <para xml:id="para_fee142d6-e600-4546-a8dc-f92b3b8decd8"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_8cbb7fb9-94cd-4abe-a4be-ecdc99e2b0fd">&gt;Geometric Maximum Distortion</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_24eba9f8-d4e5-4eef-9cfa-1ac7f59ac82c">(0028,9445)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_08d2bbf1-a753-468d-8b4c-546456a5a9c2">2C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_fa7d5ce5-8e4e-4224-9568-d3cde372393b">The percentage of the maximum deviation of the pixel spacing values of images for which the geometric properties are non-uniform.</para>
+                                        <note>
+                                            <para xml:id="para_d616851d-30ee-4063-93d6-31d1df204508">This Attribute may be used to judge the result of measurements, 3D reconstructions, etc.</para>
+                                        </note>
+                                        <para xml:id="para_a0ebc5e5-aa60-4039-bf3a-bfab2df8b3a5">Required if Geometrical Properties (0028,9444) equals NON_UNIFORM.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_b3a33389-7607-4632-8272-4f349f8bcedf">&gt;Image Processing Applied</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f57efd30-59ca-4f5d-ae7c-7377eb32e1a0">(0028,9446)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f0775a51-fea7-4b99-a6d8-23fc4fe15f22">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c5556329-3d9e-4a14-ad5a-f2c24e86fe98">The type or a combination of types of image processing applied to the pixel data before being stored.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Defined Terms:</title>
+                                            <varlistentry>
+                                                <term>DIGITAL_SUBTR</term>
+                                                <listitem>
+                                                    <para xml:id="para_a66377db-4865-484b-8352-83add16ad87a"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>HIGH_PASS_FILTER</term>
+                                                <listitem>
+                                                    <para xml:id="para_d14e0a22-8c1e-4023-9051-92b4aa037f27"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>LOW_PASS_FILTER</term>
+                                                <listitem>
+                                                    <para xml:id="para_bd4c5e5e-78dd-49c7-89b5-5b799807f94b"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>MULTI_BAND_FLTR</term>
+                                                <listitem>
+                                                    <para xml:id="para_9864075f-239a-4195-baf8-676fe1d68a48"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>FRAME_AVERAGING</term>
+                                                <listitem>
+                                                    <para xml:id="para_641e944a-0705-49c3-8f13-0d0de5bd3887"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>NONE</term>
+                                                <listitem>
+                                                    <para xml:id="para_0266d1c4-297c-4013-83ef-d428f5dee210"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.4.1" status="6" xml:id="sect_C.8.19.6.4.1">
+                            <title>X-Ray Frame Pixel Data Properties Attributes</title>
+                            <section label="C.8.19.6.4.1.1" status="7" xml:id="sect_C.8.19.6.4.1.1">
+                                <title>Pixel Intensity Relationship</title>
+                                <para xml:id="para_fe473f8d-5a48-4d8b-bb99-c91d6fe86995">Pixel Intensity Relationship (0028,1040) shall identify the relationship of the pixel values to the X-Ray beam intensity.</para>
+                                <variablelist spacing="compact">
+                                    <title>Defined Terms:</title>
+                                    <varlistentry>
+                                        <term>LIN</term>
+                                        <listitem>
+                                            <para xml:id="para_fc838532-94c9-4f25-8753-417c14ace79d">Approximately proportional to X-Ray beam intensity.</para>
+                                        </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
+                                        <term>LOG</term>
+                                        <listitem>
+                                            <para xml:id="para_e993cafe-644c-4818-950b-3b786233b53d">Non-linear "Log Function"; A Pixel Intensity Relationship LUT shall be included with the image to allow it to be mapped back to its proportional value to X-Ray beam intensity.</para>
+                                        </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
+                                        <term>OTHER</term>
+                                        <listitem>
+                                            <para xml:id="para_e4135f38-3369-4e0c-87d8-1a0437860ce0">Not proportional to X-Ray beam intensity. If a TO_LINEAR Pixel Intensity Relationship LUT Item is supplied, scaling back to X-Ray beam intensity is possible.</para>
+                                        </listitem>
+                                    </varlistentry>
+                                </variablelist>
+                                <para xml:id="para_545534fc-cab2-4f73-8222-f3993bfcc0b2">
+                                    <note>
+                                        <orderedlist numeration="arabic">
+                                            <listitem>
+                                                <para xml:id="para_83018cc7-6576-4ff6-aebf-70ccc4e1e0e1">When the relationship can be better defined (e.g., square root data) a more precise Defined Term can be used than OTHER.</para>
+                                            </listitem>
+                                            <listitem>
+                                                <para xml:id="para_cc699f5f-e6b5-452c-b0ff-46372a6ccfcb">Providing a TO_LINEAR Pixel Intensity Relationship LUT is encouraged.</para>
+                                            </listitem>
+                                        </orderedlist>
+                                    </note>
+                                </para>
+                            </section>
+                            <section label="C.8.19.6.4.1.2" status="7" xml:id="sect_C.8.19.6.4.1.2">
+                                <title>Imager Pixel Spacing</title>
+                                <para xml:id="para_159ce397-7813-4713-b021-9370d98eef2e">The two values of the Imager Pixel Spacing (0018,1164) Attribute are related to the value(s) of the Field of View Dimension(s) in Float (0018,9461) Attribute in the X-Ray Field of View Functional Group of this frame and the values of the Rows (0028,0010) and Columns (0028,0011) Attributes.</para>
+                                <para xml:id="para_e1f6bdd9-e597-4219-8992-31bc27680cf0">The value(s) of Field of View Dimension(s) in Float (0018,9461) may change on a frame by frame base. The values of the Rows and Columns Attributes are equal for all frames. The relationship between the Attributes depends on the Field of View Shape (0018,1147) Attribute:</para>
+                                <para xml:id="para_88a71b68-2bb7-483c-8193-c4acc646e64b">If the Field of View Shape (0018,1147) Attribute equals RECTANGLE:</para>
+                                <para xml:id="para_d099816f-2dc8-4ecb-a9a2-47c6df668977">Imager Pixel Spacing<subscript>row spacing</subscript> = FOV Dimension<subscript>row dimension</subscript> / Rows</para>
+                                <para xml:id="para_13577f34-7c92-4ca9-86b8-adc211a77093">Imager Pixel Spacing<subscript>column spacing</subscript> = FOV Dimension<subscript>column dimension</subscript> / Columns</para>
+                                <para xml:id="para_9e59ec03-6d81-453a-9cfc-5ec551f8d279">If the Field of View Shape (0018,1147) Attribute equals ROUND or HEXAGONAL:</para>
+                                <para xml:id="para_c1f449af-e4a5-4481-b914-9052a5beb783">Imager Pixel Spacing<subscript>row spacing</subscript> = FOV Dimension<subscript>diameter</subscript> / Rows</para>
+                                <para xml:id="para_8e877f2a-4ae6-4cd4-8189-95d75ff75635">Imager Pixel Spacing<subscript>column spacing</subscript> = FOV Dimension<subscript>diameter</subscript> / Columns</para>
+                            </section>
+                            <section label="C.8.19.6.4.1.3" status="7" xml:id="sect_C.8.19.6.4.1.3">
+                                <title>Pixel Data Area Relative to FOV</title>
+                                <para xml:id="para_0c121788-a300-47b8-98e3-deada26df696">In the case where the Field of View does not have the same size as the stored Pixel Data (7FE0,0010), the stored Pixel Data (7FE0,0010) may be the result of cropping, rotation, resizing and/or padding of the Field of View. The following Attributes specify the relationship of the Pixel Data area to the Field Of View Area:</para>
+                                <itemizedlist>
+                                    <listitem>
+                                        <para xml:id="para_85cbb047-f89d-4b6e-a8e8-f651842abeb6">Pixel Data Area Origin Relative to FOV (0018,7036)</para>
+                                    </listitem>
+                                    <listitem>
+                                        <para xml:id="para_330b9bc6-2c39-4e84-9b07-aa0baebf8bc3">Pixel Data Area Rotation Angle Relative to FOV (0018,7038)</para>
+                                    </listitem>
+                                </itemizedlist>
+                                <note>
+                                    <para xml:id="para_303c4d0d-bbbd-4984-9999-591885e78975">In order to make use of the Pixel Data Area Origin Relative to FOV (0018,7036), the Imager Pixel Spacing (0018,1164) is needed.</para>
+                                </note>
+                                <para xml:id="para_5b7f80d8-c44c-4928-b032-84ea0bb799de">
+                                    <figure label="C.8.19.6.4-1" pgwide="1" xml:id="figure_C.8.19.6.4-1">
+                                        <title>Explanation of Pixel Data Area Attributes</title>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6.4-1.svg"/>
+                                                <!--<imagedata fileref="part03_fromword_files/image249.png"/>-->
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                            </section>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.5" status="5" xml:id="sect_C.8.19.6.5">
+                        <title>X-Ray Frame Detector Parameters Macro</title>
+                        <para xml:id="para_4c4977df-d1ea-446a-aeeb-e0541455dabc">
+                            <xref linkend="table_C.8.19.6-5" xrefstyle="select: label"/> specifies the Attributes containing the X-Ray Frame Detector Parameters Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-5" rules="all" xml:id="table_C.8.19.6-5">
+                            <caption>X-Ray Frame Detector Parameters Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_44eb082b-5797-49b0-b5a4-9a7ec427b48c">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_072f308f-f299-46c0-8922-6bce212d8d9c">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e1a4c0d1-dc3b-481e-9bed-2133dfd55d7c">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_471fd323-c68d-4bbe-b7e5-e56f1cc78c9a">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d8ed5092-ba47-43d1-8b71-ba0b184a24f5">Frame Detector Parameters Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a4434a72-c967-473a-92bc-b3c40e7652f9">(0018,9451)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_86cd2c70-bf9d-4168-a092-e302f5dd8f04">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1f2ee712-6fea-4d3a-ac91-0b653d1c4156">Sequence containing the detector properties for this frame.</para>
+                                        <para xml:id="para_27fd886c-c5d8-4fb5-baf4-372f7c1dba26">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_9c5e20f1-3bfb-4789-9b64-c305264ec68c">&gt;Detector Active Time</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7018ec77-e313-47dd-8ae1-3842d53134a4">(0018,7014)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3544ebb8-c0c7-441c-897d-9a6ad758e960">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_053b6e94-3cea-47d0-83bf-c4f44e55507b">Time in mSec that the detector is active during acquisition of this image.</para>
+                                        <note>
+                                            <para xml:id="para_3dc0facc-4139-4f4e-ac14-e1978cb68b6a">This activation window overlaps the time of the X-Ray exposure as defined by Exposure Time in ms (0018,9328) and Detector Activation Offset From Exposure (0018,7016).</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d60a8f7f-8bf9-42e6-abad-962392117b9d">&gt;Detector Activation Offset From Exposure</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_883b4d85-3696-41e6-8be0-b0b829539460">(0018,7016)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2eeb3949-dd1d-4c51-b343-f5b4a1bd4476">3</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_65824b6c-d748-4b2c-beab-b46577f94a4d">Offset time in mSec that the detector becomes active after the X-Ray beam is turned on during acquisition of this image. May be negative.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                    <section label="C.8.19.6.6" status="5" xml:id="sect_C.8.19.6.6">
+                        <title>X-Ray Calibration Device Usage Macro</title>
+                        <para xml:id="para_6a03c80d-debe-42da-ab7c-1b4b595a95bd">
+                            <xref linkend="table_C.8.19.6-6" xrefstyle="select: label"/> specifies the Attributes containing the X-Ray Calibration Device Usage Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-6" rules="all" xml:id="table_C.8.19.6-6">
+                            <caption>X-Ray Calibration Device Usage Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2ce6e47d-6419-4724-8f5e-8c1b52cd58ed">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9750c1ba-e394-440e-ad4a-bbec33c2e7f5">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3796dda6-f996-47cc-adb6-460db12b45ac">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1ccdb907-7fe9-4f6d-84ef-499685df7d97">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1bd077b8-1548-4ac4-8f87-41cbcce97509">Calibration Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ec8fba57-f392-4d99-874b-8ae4990c7e5f">(0018,9455)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a68c6a0c-2872-4987-a5a5-061460d89331">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_56c40e67-63d4-4eb2-b27e-04ccb363934b">Sequence containing the calibration flag for this frame.</para>
+                                        <para xml:id="para_6e92036f-4580-45f9-9071-71b1c3f1c995">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_656bfd9a-b062-4512-b6eb-7d7958d207e5">&gt;Calibration Image</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_23679eb2-1c43-4a98-9ca8-d710f06d7ef9">(0050,0004)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_4dd253b7-abd3-4b08-bf47-2b7657f299a2">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_cb267ab0-2880-4e9b-a51e-053d6d957b81">Indicates whether a reference object (phantom) of known size is present in the frame and was used for calibration.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>YES</term>
+                                                <listitem>
+                                                    <para xml:id="para_c109f923-3c64-40f4-8388-3f4ee1387c8a"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>NO</term>
+                                                <listitem>
+                                                    <para xml:id="para_ef4d9bf3-6a0a-4fd0-8263-c3cc259475f6"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                        <note>
+                                            <para xml:id="para_41375bd0-b690-4b84-b3c7-8a3091b6b3f9">Device is identified using the <xref linkend="sect_C.7.6.12" xrefstyle="select: title"/>. See <xref linkend="sect_C.7.6.12" xrefstyle="select: label"/>.</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                    <section label="C.8.19.6.7" status="5" xml:id="sect_C.8.19.6.7">
+                        <title>X-Ray Object Thickness Macro</title>
+                        <para xml:id="para_45cde776-174d-457a-9d9c-2de5e5c840e6">
+                            <xref linkend="table_C.8.19.6-7" xrefstyle="select: label"/> specifies the Attributes containing the X-Ray Object Thickness Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-7" rules="all" xml:id="table_C.8.19.6-7">
+                            <caption>X-Ray Object Thickness Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_0d39e4a1-c791-4702-9d40-af5a236f5839">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b9fbbc3f-6b64-4897-9b3c-e506762d21b9">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b37039cc-a0e0-4f59-84c8-71157bfb7dca">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_90154c1a-6d60-4bc9-bf79-37f17a4e2e44">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_cefea8f1-62ec-4a39-a71d-f68eb13512e2">Object Thickness Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_4444492f-2180-4439-88bc-92b9bda413b9">(0018,9456)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_8d754afa-fa5a-4bb9-8c83-da61af29a934">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_155f06c4-6705-4882-9c73-bf50ee1bcad9">Sequence containing object thickness for this frame.</para>
+                                        <para xml:id="para_33205c91-2eda-4c30-b20f-a1a4342e1cd9">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_cf38d3c7-c6be-4120-ada2-0572e40b63ca">&gt;Calculated Anatomy Thickness</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_8d08ed8a-ac88-4c09-a817-098701bab8da">(0018,9452)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3e40de18-5b52-47ae-b173-a449337efe51">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_8e61d70a-85f7-4d5e-a383-ca75fc31c06a">The physical thickness in mm of the anatomic region of interest as specified in the Anatomic Region Sequence (0008,2218) in the direction of the center of the beam.</para>
+                                        <note>
+                                            <para xml:id="para_f73c3582-d5ae-42c2-80f6-c46ec5861bc8">The value takes in account the position relative to object and the X-Ray source - detector axis.</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                    <section label="C.8.19.6.8" status="5" xml:id="sect_C.8.19.6.8">
+                        <title>X-Ray Frame Acquisition Macro</title>
+                        <para xml:id="para_a6fba7e2-1761-4df3-82aa-6dfd324983e1">
+                            <xref linkend="table_C.8.19.6-8" xrefstyle="select: label"/> specifies the Attributes containing the X-Ray Frame Acquisition Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-8" rules="all" xml:id="table_C.8.19.6-8">
+                            <caption>X-Ray Frame Acquisition Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_afb364a8-af59-4b1a-b75b-6e954cdaf8c3">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2f4cab09-a550-4b7e-9db9-762358b4ceb2">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d4068b0f-02d7-485f-8f81-b80e01b301b0">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_573e006c-e4d6-418c-ac97-31bfe5164a5d">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_9f4b1e92-063b-4bee-a60b-361a002b9382">Frame Acquisition Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ba525b94-5cbe-41a4-9028-942f074ff9fa">(0018,9417)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_41dd2f67-840b-4f53-a851-fbd373580955">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_be5c6650-a612-4216-99ac-e144e9dd421a">Sequence containing the acquisition parameters for this frame.</para>
+                                        <para xml:id="para_c7b0f31b-bf2d-4ae2-9722-67a83382130b">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_8e36cbbd-130b-4bd2-8318-bd005eccf53e">&gt;KVP</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5742882a-121c-4d5c-abc3-3ae60ea36714">(0018,0060)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_aec70eda-74e9-4528-bd5b-f6eed03a94e3">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_03658f6e-5b89-437e-9eb4-93a1f0443e41">Exact peak kilo voltage output of the X-Ray generator used for this frame.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_e103e58e-f771-45b0-ad35-b96eee080d7a">&gt;X-Ray Tube Current in mA</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_26165ecc-b516-4b92-9425-4340bdd59319">(0018,9330)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ee0417f1-b5f8-437d-beb2-4135459bf4c1">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_cd252eb9-6266-48cb-94e4-1f13f43b3ad6">Exact Nominal X-Ray tube current in milliamperes applied during Acquisition Duration (0018,9220) for this frame.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.8.1" status="6" xml:id="sect_C.8.19.6.8.1">
+                            <title>X-Ray Frame Acquisition Sequence Attributes</title>
+                            <para xml:id="para_06a7436d-19bd-4936-a5d2-776eca53126c">These Attributes may only be used if the information is available on a frame-by-frame base. The average values for these Attributes of all frames shall be stored in the same Attribute in the <xref linkend="sect_C.8.19.3" xrefstyle="select: title"/> or in the <xref linkend="sect_C.8.31.1" xrefstyle="select: title"/>.</para>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.9" status="5" xml:id="sect_C.8.19.6.9">
+                        <title>X-Ray Projection Pixel Calibration Macro</title>
+                        <para xml:id="para_683ba200-3b09-4f6f-97b1-b2b6a07ed321">
+                            <xref linkend="table_C.8.19.6-9" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Projection Pixel Calibration Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-9" rules="all" xml:id="table_C.8.19.6-9">
+                            <caption>X-Ray Projection Pixel Calibration Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_acbdefe3-241c-4bb2-a67c-07fee1adeb29">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b6c2b82e-da4e-4632-aee2-9ce29c6c3fcc">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_8cab0a4e-0ad9-4ec0-a1b9-36b3026d8fbd">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_4dd152a8-4c04-452b-bb54-c22f0cba4204">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_7df03cb5-2293-419f-8fd1-dc802500f2ab">Projection Pixel Calibration Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b55eb23e-98ca-4768-981f-bb8f706d9a57">(0018,9401)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5644e442-d2fc-4e12-a732-40d957455da7">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_624db768-6b2c-4b91-99be-c511930ff124">A Sequence that describes the geometrical position of the patient relative to the equipment.</para>
+                                        <para xml:id="para_a5ac0cac-0877-46fc-a72f-e891bb220315">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_83668929-6d78-4075-8adb-7dd4f02eb19e">&gt;Distance Object to Table Top</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7eb349ea-8cd9-45e6-91ac-7a8793298d0d">(0018,9403)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_eb5ababf-6541-4de7-873f-c3cb045fab1a">2</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_e4c5efbe-dd67-47ed-93f2-12f2e85d52c3">Distance between the anatomic region of interest of observation and table top in mm.</para>
+                                        <note>
+                                            <orderedlist numeration="arabic">
+                                                <listitem>
+                                                    <para xml:id="para_e347991f-e69b-4a3b-8bd6-00fed7901f0a">This value is always positive, the object is assumed to be above the table.</para>
+                                                </listitem>
+                                                <listitem>
+                                                    <para xml:id="para_a503c034-8d56-44e1-a21e-44f2f8968d92">The value of this Attribute is depending on the patient position on the tabletop (supine, left or right decubitus, etc.)</para>
+                                                </listitem>
+                                            </orderedlist>
+                                        </note>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_a21794dc-5d4d-4d35-9f9e-1bf996bc1741">&gt;Object Pixel Spacing in Center of Beam</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b71419ba-08fd-4fb6-9587-a54114904262">(0018,9404)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a9eb80f9-ca14-4bae-9ceb-c7b62acc392a">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_27539cc0-46f3-4ad9-a798-1e7ba57e0e85">Physical distance within the anatomic region of interest in the center of the beam and perpendicular to the beam between the center of each pixel, specified by a numeric pair adjacent row spacing (delimiter) adjacent column spacing in mm. See <xref linkend="sect_C.8.19.6.9.2" xrefstyle="select: label"/>. See <xref linkend="sect_10.7.1.3" xrefstyle="select: label"/> for further explanation of the value order.</para>
+                                        <para xml:id="para_c31efb57-a6fc-4a33-a1b1-eaa15dc46b99">Required if Distance Object to Table Top (0018,9403) is not empty.</para>
+                                        <note>
+                                            <para xml:id="para_3a7016b2-4fe4-425c-b102-2c5372c90e39">This value is provided besides the values that are the input parameters of the calibration algorithm.</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_db8b900b-8949-42e6-9da4-9b9d88b42a61">&gt;Table Height</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_12cc2d86-55f6-4c21-9730-3f8f96a9eb1c">(0018,1130)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c5715a44-9fab-4826-a67c-cc5581939c4f">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_f454c693-c186-4f87-bbd9-17f4a1777882">The distance of the top of the patient table to the center of rotation of the source (i.e., the isocenter) in mm. A positive value indicates that the tabletop is below the isocenter.</para>
+                                        <note>
+                                            <para xml:id="para_d181ba0a-ee71-47ee-81b0-747817340ddb">All the distances are measured perpendicular to the Table Top plane.</para>
+                                        </note>
+                                        <para xml:id="para_89065272-f9c2-4193-ba57-3c27a47028ba">Required if Image Type (0008,0008) Value 1 is ORIGINAL, may be present otherwise.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_2e6baeea-58e7-45ff-b8d0-bf0c683c0be7">&gt;Beam Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_975f6e95-220c-416c-95a5-030ac127ea49">(0018,9449)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_6935d0cc-f2f7-4233-8e72-13d5d5660d9e">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_145a2893-937f-4607-beda-9fd4ddb93718">The equipment related angle in degrees of the X-Ray beam relative to the perpendicular to the tabletop plane. An angle from 0 to +90 degrees indicates that the X-Ray source is below the table.</para>
+                                        <para xml:id="para_e075b31e-98ed-48c6-b420-675d9e381386">The valid range is 0 to +180 degrees.</para>
+                                        <para xml:id="para_bd4eba34-e4f5-4923-acac-2a3a6bb87267">Required if Image Type (0008,0008) Value 1 is ORIGINAL, may be present otherwise.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.9.1" status="6" xml:id="sect_C.8.19.6.9.1">
+                            <title>Projection Calibration Method</title>
+                            <para xml:id="para_8906d120-cd3e-4c6c-acca-48c4d8c98a18">The X-Ray Projection Pixel Calibration Macro defines the Attributes needed to completely describe the specific inputs and results from projection image pixel calibration based on isocenter reference. The Attributes are provided to allow usage of calibration result as well as recalibration. <xref linkend="figure_C.8.19.6-1" xrefstyle="select: label"/> and <xref linkend="figure_C.8.19.6-2" xrefstyle="select: label"/> illustrate the relationship of the Attributes.</para>
+                            <para xml:id="para_0a90e823-292e-488d-a01b-832335ee72a4">In <xref linkend="figure_C.8.19.6-1" xrefstyle="select: label"/> and <xref linkend="figure_C.8.19.6-2" xrefstyle="select: label"/>, the object of interest of size D (in mm) is projected on the stored image over a distance of #Px (in pixels). The pixel spacing on the stored image is called DPx. The "Source to Isocenter Distance" is called ISO. The "Source Image Receptor Distance" is called SID. The shortest distance from the tabletop plane to the Isocenter and to the object of interest are called respectively TH and TO. The angle between the X-Ray beam and the axis perpendicular to the tabletop plane is called Beam Angle. Finally, the distance from the X-Ray source to the object of interest in the direction of the X-Ray beam is called SOD and is calculated from the other distances.</para>
+                            <para xml:id="para_43a9b4f6-a0a2-43a1-a95b-cb9049638296">DPx: Imager Pixel Spacing (0018,1164)</para>
+                            <para xml:id="para_2cc6a6da-bf07-46f9-a2d9-bec08db01362">ISO: Source Isocenter Distance (0018,9402)</para>
+                            <para xml:id="para_5bbcc33a-1d3f-4d49-b41c-c46e9e934494">SID: Distance Source to Detector (0018,1110)</para>
+                            <para xml:id="para_14a7b3f4-46d8-4ed5-9516-99dc6045ffc2">TH: Table Height (0018,1130)</para>
+                            <para xml:id="para_358f1bb2-d73f-46a2-aefa-b299d4e0b263">TO: Distance Object to Table Top (0018,9403)</para>
+                            <para xml:id="para_33448bb5-e153-469c-9841-73ace434cf9b">Beam Angle: Beam Angle (0018,9449)</para>
+                            <note>
+                                <para xml:id="para_a72a15ed-1d61-464e-a985-12a000aacebc">The equipment related Beam Angle (0018,9449) Attribute shall be consistent with the patient oriented Positioner Primary Angle (0018,1510) and Positioner Secondary Angle (0018,1511) together with the patient orientation on the table specified in Patient Orientation Code Sequence (0054,0410) Attributes.</para>
+                            </note>
+                            <para xml:id="para_28c24082-16e4-428e-918f-bb9310735b26">
+                                <xref linkend="figure_C.8.19.6-1" xrefstyle="select: label"/> and <xref linkend="figure_C.8.19.6-2" xrefstyle="select: label"/> illustrate the usage of the Attributes under the conditions laid out above.</para>
+                            <para xml:id="para_6ed6fc58-1646-447c-b15d-2ef757544e3a">
+                                <figure label="C.8.19.6-1" pgwide="1" xml:id="figure_C.8.19.6-1">
+                                    <title>Projection Calibration Without Angulation of the X-Ray Beam (Beam Angle = 0)</title>
+                                    <mediaobject>
+                                        <imageobject>
+                                            <imagedata fileref="figures/PS3.3_C.8.19.6-1.svg"/>
+                                            <!--<imagedata fileref="part03_fromword_files/image251.png"/>-->
+                                        </imageobject>
+                                    </mediaobject>
+                                </figure>
+                            </para>
+                            <para xml:id="para_1ade4708-7834-4ff5-ac75-42077e5dc03e">
+                                <figure label="C.8.19.6-2" pgwide="1" xml:id="figure_C.8.19.6-2">
+                                    <title>Projection Calibration With Angulation of the X-Ray Beam (Beam Angle Not Equal to 0)</title>
+                                    <mediaobject>
+                                        <imageobject>
+                                            <imagedata fileref="figures/PS3.3_C.8.19.6-2.svg"/>
+                                            <!--<imagedata fileref="part03_fromword_files/image253.png"/>-->
+                                        </imageobject>
+                                    </mediaobject>
+                                </figure>
+                            </para>
+                        </section>
+                        <section label="C.8.19.6.9.2" status="6" xml:id="sect_C.8.19.6.9.2">
+                            <title>Object Pixel Spacing in Center of Beam</title>
+                            <para xml:id="para_1d9849d9-cdea-4ed5-b494-44b0bbc55a55">The value provided for Beam Angle (0018,9449) shall correspond to the other Attribute values within this Module and according to the mathematic terms listed in <xref linkend="sect_C.8.19.6.9.1" xrefstyle="select: label"/>.</para>
+                            <para xml:id="para_7b943d53-aee1-4f53-a93d-13eb82b1284a">The terms listed will result in infinite result when used with 90-degree beam angles.</para>
+                            <para xml:id="para_1d61eac6-33fe-428c-b1a9-160d1307365a">It is outside the scope of this Standard to define reasonable limits for single input values in the above-mentioned terms, or to define the mathematical accuracy of applications using those terms.</para>
+                            <note>
+                                <para xml:id="para_dc99bae9-d512-4919-9030-f4f6f799138b">It may be reasonable to limit automatic calculations to a narrow range of +/- 60 degrees for Beam Angle and inform users about possible deviations in the calibration result when exceeding such range limits.</para>
+                            </note>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.10" status="5" xml:id="sect_C.8.19.6.10">
+                        <title>X-Ray Positioner Macro</title>
+                        <para xml:id="para_d56cb472-4916-47dd-b021-06dd300b77b4">
+                            <xref linkend="table_C.8.19.6-10" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Positioner Functional Group Macro. If included into the Shared Functional Groups Sequence (5200,9229) no DYNAMIC motion was performed during acquisition. If included in the Per-frame Functional Groups Sequence (5200,9230) the indication of a DYNAMIC motion is given.</para>
+                        <table frame="box" label="C.8.19.6-10" rules="all" xml:id="table_C.8.19.6-10">
+                            <caption>X-Ray Positioner Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_8d372df4-36e3-400d-ab96-cfb84709ee91">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_aed2ad43-4909-40ee-ba9f-4501566b3693">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d54473c5-7305-49dd-8448-c8ef20a82e5c">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b633a528-1558-475e-981e-dbc7bcb0813b">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_fd5da7d3-5e39-4d6c-b2f9-db3a14ab1ace">Positioner Position Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_0efde76d-ce6f-45e6-a7ac-e3630d9c6c04">(0018,9405)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_727a82a0-946e-4bcb-bb82-49fc87f3308f">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_929a870f-f582-47c6-8ff3-5925e2c2bbe9">A Sequence that describes the geometrical position of the positioner.</para>
+                                        <para xml:id="para_11879f4e-46d1-48f5-9a90-bd63888d42f5">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_f99b9640-4969-4744-bb18-ff38eeed39a7">&gt;Positioner Primary Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7c1066f9-eb2b-411e-9ddf-01ace50dd4e1">(0018,1510)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ebeba6cf-8439-4477-827d-7986cbefd500">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_2b058552-cb99-40eb-a667-87cb983eab6d">Position of the X-Ray Image Intensifier about the patient from the RAO to LAO direction where movement from RAO to vertical is positive.</para>
+                                        <para xml:id="para_697bdf2a-f03f-4cd6-9003-f14f87d420ef">See <xref linkend="sect_C.8.7.5.1.2" xrefstyle="select: label"/>.</para>
+                                        <para xml:id="para_d4bebdca-5466-49c1-a570-f9a6696697a6">Required if Positioner Type (0018,1508) equals CARM.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_76a56af4-4ede-44a6-82f1-3c0374e7ccc6">&gt;Positioner Secondary Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7df8ade4-6511-4e45-b19f-14638fceb8e4">(0018,1511)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_89ee3b33-71de-4199-bf53-dbab491a36de">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_debc5cd7-7105-41f1-8d77-632e8d34bc6e">Position of the X-Ray Image Intensifier about the patient from the CAU to CRA direction where movement from CAU to vertical is positive.</para>
+                                        <para xml:id="para_94753327-8579-4ff6-9050-1dfca983fbf1">See <xref linkend="sect_C.8.7.5.1.2" xrefstyle="select: label"/>
+                                        </para>
+                                        <para xml:id="para_ded388d9-dba0-4d1e-a229-489c96536b3b">Required if Positioner Type (0018,1508) equals CARM.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_233ba29d-7c03-4701-9b03-c9f42bfc2ded">&gt;Column Angulation (Patient)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ebfd7aec-7382-4e1f-9fed-4302fba89e4c">(0018,9447)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1cecc200-eefd-4337-8587-06832739b309">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_0adf594e-bead-49da-b750-035dcbb1f18f">Angle of the X-Ray beam in degree relative to an orthogonal axis to the detector plane. Positive values indicate that the tilt is towards the head of the patient.</para>
+                                        <note>
+                                            <orderedlist numeration="arabic">
+                                                <listitem>
+                                                    <para xml:id="para_5c473ee7-d4b5-46fe-a53c-b81ab245b9b2">The detector plane is assumed to be parallel to the table plane</para>
+                                                </listitem>
+                                                <listitem>
+                                                    <para xml:id="para_821d3467-058f-40a9-bf0e-2664be76d7bb">This Attribute differentiates form the Attribute Column Angulation (0018,1450) by using the Patient-Based Coordinate System instead of the Equipment-Based Coordinate System.</para>
+                                                </listitem>
+                                            </orderedlist>
+                                        </note>
+                                        <para xml:id="para_1d081588-d66a-444e-8319-30960602f5e4">Required if Positioner Type (0018,1508) equals COLUMN.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                    <section label="C.8.19.6.11" status="5" xml:id="sect_C.8.19.6.11">
+                        <title>X-Ray Table Position Macro</title>
+                        <para xml:id="para_3c60f841-bb2d-4451-8062-7ed38fd0e740">
+                            <xref linkend="table_C.8.19.6-11" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Table Position Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-11" rules="all" xml:id="table_C.8.19.6-11">
+                            <caption>X-Ray Table Position Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_29f13e30-a01f-4e44-abbe-7a5335f09175">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b9711089-270c-4263-9f98-b6b7629ce693">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c8ad3dda-2777-4660-a166-3f5d92538fd2">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_72d91dda-2bf4-49f3-8ce5-8d92b23819b9">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_59af7a2f-439f-488a-b896-4ae9b0024304">Table Position Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_6582f00d-5681-466b-983f-77b9d70fc85f">(0018,9406)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a83c544f-57b3-4044-9a83-9b95fbe5c628">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_3deb1e59-cf48-450f-9e20-a937a78695e2">A Sequence that describes the geometrical position of the table top.</para>
+                                        <para xml:id="para_5c290f88-7286-48c1-8fc1-65a49c154c91">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_13864486-b35f-4e5c-8e69-5d56280a29cb">&gt;Table Top Vertical Position</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_20cf22e4-5461-4e94-9319-87857483d0f8">(300A,0128)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_0e173ec4-a760-426e-b5f0-6bf6135891bf">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_f0692f4f-fd02-4261-b6ce-ed7208ba78f6">Table Top Vertical position with respect to an arbitrary chosen reference by the equipment in (mm). Table motion downwards is positive</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_ae6eb42a-870b-442d-8c57-dedc0e4c371a">&gt;Table Top Longitudinal Position</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a694ece0-7d60-497b-b04f-3f67e2ba4565">(300A,0129)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_17815d6e-92ee-4e71-aa6e-4731697f82d1">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_beb5df61-2ccb-499b-94d4-b455b5b5ac7d">Table Top Longitudinal position with respect to an arbitrary chosen reference by the equipment in (mm). Table motion towards LAO is positive assuming that the patient is positioned supine and its head is in normal position.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_35097a69-2e7b-4c91-935a-b137679c8123">&gt;Table Top Lateral Position</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ae263e3e-8274-453c-b72f-157832d8975c">(300A,012A)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1fe1048b-b641-48a2-b282-60886988a9f2">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_eb2f70a3-845b-4a0b-98fe-b6cba2124023">Table Top Lateral position with respect to an arbitrary chosen reference by the equipment in (mm). Table motion towards CRA is positive assuming that the patient is positioned supine and its head is in normal position.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1543dbb8-8d76-4720-b305-ade5de3f6287">&gt;Table Horizontal Rotation Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_efcb7d13-55a8-4b03-b69e-6272b0c11d3a">(0018,9469)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e99df982-8da2-42f5-8592-b5e754c4d474">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_74ef41e3-9e1d-409b-871e-83fe6e448954">Rotation of the table in the horizontal plane (clockwise when looking from above the table).</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_bf751938-9823-40ed-a301-14e291f58bff">&gt;Table Head Tilt Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e0fd1285-24aa-4295-923c-4aa23424163b">(0018,9470)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c6eeee90-d124-4a6e-abf5-e064a00f3d7b">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_e165c5a1-6d53-410d-a1a6-8e2cd1137f8c">Angle of the head-feet axis of the table in degrees relative to the horizontal plane. Positive values indicate that the head of the table is upwards.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_29cb1714-d26f-45d3-9b75-51dc3777bfdd">&gt;Table Cradle Tilt Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e9755539-198d-4bcf-818b-6e2795024cdd">(0018,9471)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_91f946c8-ee64-4b87-a5c8-9b9aba72d511">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_ded3409a-2241-40bf-8a06-80562bd6e063">Angle of the left-right axis of the table in degrees relative to the horizontal plane. Positive values indicate that the left of the table is upwards.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.11.1" status="6" xml:id="sect_C.8.19.6.11.1">
+                            <title>X-Ray Table Position Macro Attribute Description</title>
+                            <para xml:id="para_c67ef2dc-e42b-4de0-b432-c06d65e45fd4">The Table Top Position Attributes of the Table Position Sequence (0018,9406) specify the geometrical position of the Table in the three spatial directions (i.e., Vertical, Longitudinal and Lateral) relative to the Table Top plane (see <xref linkend="figure_C.8.19.6-3" xrefstyle="select: label"/>). The absolute reference point to which the Table positions are related is arbitrarily defined by the manufacturer.</para>
+                            <para xml:id="para_db3c33c7-c1f6-4ab1-bfcc-79ea6ca4361b">The Table Angle Attributes of the Table Position Sequence (0018,9406) specify the rotation and tilt of the Table Top Plane with respect to a plane arbitrarily defined by the manufacturer (usually the horizontal plane).</para>
+                            <para xml:id="para_e2a2fc9f-df0c-4951-9843-fe6c07c8516e">The Table Top Position Attributes allow to describe the incremental translation of the Table top between frames of the same Multi-frame image, and between frames of different images, provided that the Table Angles are not modified between these frames.</para>
+                            <para xml:id="para_ab887fd4-1e75-40a7-85f2-b690e52d097d">When the table angles are modified between two frames, the Table Position Sequence (0018,9406) does not allow to characterize the relationship between the two table positions in an absolute reference coordinate system. For this purpose, the X-Ray Isocenter Reference System Macro has to be used.</para>
+                            <note>
+                                <para xml:id="para_057467bb-5bdb-4fa9-9716-fc361107303c">The incremental table translation may be used, in conjunction with the Positioner Position Sequence Attributes (0018,9405), for simple 2D-2D registration applications (object tracking, pixel shift…), assuming that the patient position is fixed on the table. For more complex registration applications, and in order to properly handle the changes in the table angles, it is recommended to use the X-Ray Isocenter Reference System Macro Attributes.</para>
+                            </note>
+                            <para xml:id="para_9653dfbd-49c5-40c9-93f2-29d400aa1697">
+                                <figure label="C.8.19.6-3" pgwide="1" xml:id="figure_C.8.19.6-3">
+                                    <title>Table Position Vectors</title>
+                                    <mediaobject>
+                                        <imageobject>
+                                            <imagedata fileref="figures/PS3.3_C.8.19.6-3.svg"/>
+                                        </imageobject>
+                                    </mediaobject>
+                                </figure>
+                            </para>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.12" status="5" xml:id="sect_C.8.19.6.12">
+                        <title>X-Ray Collimator Macro</title>
+                        <para xml:id="para_7801ead6-bdd4-4521-bff7-b9d27b94c0dc">
+                            <xref linkend="table_C.8.19.6-12" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Collimator Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-12" rules="all" xml:id="table_C.8.19.6-12">
+                            <caption>X-Ray Collimator Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_8537731e-1b0a-4804-a4c1-2cbd80e13fb0">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_57d6c89b-3b60-471d-a42f-34b718aa255d">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7a301851-1068-4d33-b799-1f4068c599b4">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_0743fc4b-c033-4aca-a4cd-8ad433a5aa2b">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_a9157c47-d25f-4148-9d43-7ab7e906d296">Collimator Shape Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a1c6c011-a932-4ddc-a00d-a79fd04310bf">(0018,9407)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1293895e-4590-49c5-9f9f-8e53db7bb9a2">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_37637a87-f100-4148-8f94-c70762364314">A Sequence that describes the collimator shape.</para>
+                                        <para xml:id="para_850661bc-39eb-420a-a0e7-9413e2d27ec3">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_05965d36-66e7-4222-a83d-afd7027b98c6">&gt;Collimator Shape</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c9141c00-9bef-457b-925a-53604684fcd7">(0018,1700)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2a80f46d-932c-459b-88df-784e295d7322">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_6d12e77f-1550-447b-8cc1-fa9326557ef8">Shape(s) of the collimator.</para>
+                                        <variablelist spacing="compact">
+                                            <title>Enumerated Values:</title>
+                                            <varlistentry>
+                                                <term>RECTANGULAR</term>
+                                                <listitem>
+                                                    <para xml:id="para_40ccf5df-0529-4b14-b975-7a4ce6addda6"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>CIRCULAR</term>
+                                                <listitem>
+                                                    <para xml:id="para_599ca711-cf05-4eed-9291-7e3d8a25ca28"/>
+                                                </listitem>
+                                            </varlistentry>
+                                            <varlistentry>
+                                                <term>POLYGONAL</term>
+                                                <listitem>
+                                                    <para xml:id="para_c3784c01-8532-4bba-a3f3-f94212659a51"/>
+                                                </listitem>
+                                            </varlistentry>
+                                        </variablelist>
+                                        <para xml:id="para_bb31be6f-615f-4800-abd7-3c606cf4b7f3">This multi-valued Attribute shall contain at most one of each Enumerated Value.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c8f83576-a479-41c1-8781-efd30b41dcb3">&gt;Collimator Left Vertical Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_04a8c478-9c30-4a99-b17f-7620a3b8d190">(0018,1702)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_6c2bf203-2ce3-4af9-8e7d-b1b04f17c253">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_6157282c-8089-4321-87d3-a223a0dfe0bd">Required if Collimator Shape (0018,1700) is RECTANGULAR. Location of the left edge of the rectangular collimator expressed as effective pixel column. See <xref linkend="sect_C.8.7.3.1.1" xrefstyle="select: label"/> and <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_42ca9279-513a-4c0c-b1dd-6d069551a2a5">&gt;Collimator Right Vertical Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_4acfd66a-cc7c-4e13-a520-15a47a71a609">(0018,1704)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_6966df61-0daa-4f65-98c6-422fa90cf5c1">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_0fccc3c8-5ed5-4d24-953e-fef6ef8d1c1c">Required if Collimator Shape (0018,1700) is RECTANGULAR. Location of the right edge of the rectangular collimator expressed as effective pixel column. See <xref linkend="sect_C.8.7.3.1.1" xrefstyle="select: label"/> and <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_94aeff64-9619-41d5-9426-1d13e5042fc0">&gt;Collimator Upper Horizontal Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5290285d-cfd1-43a8-97fe-7a58c93dbb1a">(0018,1706)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ea3fb43b-e762-4fdb-9a21-a0346725c231">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_fc41d39d-340d-437a-876f-f7cf167ea702">Required if Collimator Shape (0018,1700) is RECTANGULAR. Location of the upper edge of the rectangular collimator expressed as effective pixel row. See <xref linkend="sect_C.8.7.3.1.1" xrefstyle="select: label"/> and <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_fd7dfe8b-a58d-4ac6-ab64-5391cac8f6b9">&gt;Collimator Lower Horizontal Edge</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_46763768-3ed5-4e8a-b32c-4fbeb3c87080">(0018,1708)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2817e6e2-de51-41af-8c28-d9654dce1f08">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_fd307c13-c5fb-4268-87a1-8977f4104de1">Required if Collimator Shape (0018,1700) is RECTANGULAR. Location of the lower edge of the rectangular collimator expressed as effective pixel row. See <xref linkend="sect_C.8.7.3.1.1" xrefstyle="select: label"/> and <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_eccccdc9-0a7f-43b0-ae0f-9f55d89c2fb1">&gt;Center of Circular Collimator</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_6a21a27c-47b1-4ed9-963d-014dacfb21ee">(0018,1710)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_104738ad-a930-4851-be5b-4e7fe1375eff">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1542bdfd-fe26-4e04-8591-dc75ee904452">Required if Collimator Shape (0018,1700) is CIRCULAR. Location of the center of the circular collimator expressed as effective pixel row and column. See <xref linkend="sect_C.8.7.3.1.1" xrefstyle="select: label"/> and <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_bd5292e9-71ae-441c-ae6a-6a3464394ac6">&gt;Radius of Circular Collimator</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_87f2bbf5-fe03-447b-90b6-77b83a7628cc">(0018,1712)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_74a226a3-aa4c-4cc5-94aa-1b1a94ac0bf2">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_b83a1769-e349-4df9-b251-c07493b58ab1">Required if Collimator Shape (0018,1700) is CIRCULAR. Radius of the circular collimator expressed as effective number of pixels along the row direction. See <xref linkend="sect_C.8.7.3.1.1" xrefstyle="select: label"/> and <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_08047431-e9d9-4fc2-8fc4-a50d2f3e7e09">&gt;Vertices of the Polygonal Collimator</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9c274acd-ed7b-411e-8994-d0994b10b36b">(0018,1720)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_08cfdd0a-baa8-405f-8544-63c15589b513">1C</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d01abba4-9666-4fb5-92c4-efe6c23cd037">Required if Collimator Shape (0018,1700) is POLYGONAL.</para>
+                                        <para xml:id="para_cffe44e4-fcbd-4f8c-a67f-5e96597870de">Multiple Values where the first set of two values are:</para>
+                                        <para xml:id="para_a0ecf7e9-eaa1-4e61-ac68-9df99f914caa">row of the origin vertex;</para>
+                                        <para xml:id="para_836608ec-06a3-4fd7-bbf7-e388b952f740">column of the origin vertex.</para>
+                                        <para xml:id="para_11448ebe-50c7-4f44-bf1d-938efc96c198">Two or more pairs of values follow and are the effective pixel row and column coordinates of the other vertices of the polygon collimator. Polygon collimators are implicitly closed from the last vertex to the origin vertex and all edges shall be non-intersecting except at the vertices. See <xref linkend="sect_C.8.19.6.12.1" xrefstyle="select: label"/>.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.12.1" status="6" xml:id="sect_C.8.19.6.12.1">
+                            <title>X-Ray Collimator Attributes</title>
+                            <para xml:id="para_4b3b7684-0118-4d9d-8b6f-b9e103fc2af7">The top left pixel of the image has a pixel row and column value of 1.</para>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.13" status="5" xml:id="sect_C.8.19.6.13">
+                        <title>X-Ray Isocenter Reference System Macro</title>
+                        <para xml:id="para_41e05f0d-cd61-4acf-a077-652d87e20e8b">
+                            <xref linkend="table_C.8.19.6-13" xrefstyle="select: label"/> specifies the Attributes of the X-Ray Isocenter Reference System Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-13" rules="all" xml:id="table_C.8.19.6-13">
+                            <caption>X-Ray Isocenter Reference System Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_912a0592-4d3e-4190-84c8-23e6ef67084c">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1781e64d-4d7e-41b2-8530-3b3b21eef50a">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_83020123-f8a2-4a76-b0a2-43f82a923255">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c811c37e-edbe-4bdf-b57d-a6ecb652daec">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1e7623dd-3000-4cd4-b213-d61ee0b17446">Isocenter Reference System Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_7828afac-fefb-426b-a957-38d5ce23feb3">(0018,9462)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_07848896-92ac-424e-baea-a00f3ae57a6d">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_55785ac5-8c37-4286-9eff-2ffc14e572f1">A Sequence that describes the Isocenter Reference Coordinate System (O, X, Y, Z).</para>
+                                        <para xml:id="para_5a247302-2846-455a-8cfa-463168b417b6">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_8f32ea9d-6e7a-408d-89a6-5049f002d12e">&gt;Positioner Isocenter Primary Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1e20ee5e-5a12-4145-a8ed-ae57978c1739">(0018,9463)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_1123b840-4836-47e2-b3d1-2a9176e42ff0">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_f5976f4d-36b5-4a94-b61e-128be1071917">Position of the X-Ray center beam in the isocenter reference system in the X direction (deg).</para>
+                                        <para xml:id="para_77560e23-435f-4962-a0cc-f903e7deaa38">See <xref linkend="sect_C.8.19.6.13.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_2ef61b5f-8704-41b2-8344-dcb64a8ce25c">&gt;Positioner Isocenter Secondary Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_ca3fdec2-db44-4c91-8112-33d0f203e8f6">(0018,9464)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_682a65a3-ad04-483a-8bd1-9c68debe479d">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c82ea1b0-aee0-4d05-a8e2-ff60d50b0f64">Position of the X-Ray center beam in the isocenter reference system in the Z direction (deg).</para>
+                                        <para xml:id="para_ca5118d0-062f-42d8-a54a-e6087980367e">See <xref linkend="sect_C.8.19.6.13.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_4b0f0fcb-5468-4e67-ab63-b846714e2160">&gt;Positioner Isocenter Detector Rotation Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_a0570639-1b07-4c10-ab19-bd16b2c03f6b">(0018,9465)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2ae1250f-ea61-43b0-8c85-8ab878b666c0">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_c3bf70fa-7995-4350-be62-783dd70884c7">Rotation of the X-Ray detector plane (deg).</para>
+                                        <para xml:id="para_f4f553fc-5bc0-4c83-bbc0-0841eac6458f">See <xref linkend="sect_C.8.19.6.13.1.2" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_84ab50b0-ad61-47b7-b008-3e1af85dc293">&gt;Table X Position to Isocenter</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d804e6e0-9b7f-41fd-a974-c13f21a69c73">(0018,9466)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_67f1de19-7dcb-46de-a84f-85494e381f65">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_7b4639f6-cb65-494d-a5a3-824243c79711">X position of the Table Reference Point with respect to the Isocenter (mm).</para>
+                                        <para xml:id="para_edc513c6-aa1f-4c7d-bf2c-b5961313cfc3">See <xref linkend="sect_C.8.19.6.13.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_2cebc5fb-978e-462a-a9be-a86f816a3185">&gt;Table Y Position to Isocenter</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_c2e8e7ad-fb52-45df-bd27-641ff088fcd4">(0018,9467)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_2392f293-33df-4bb3-bf26-7a3c42a7f4a9">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_127a9786-0e8d-4f23-8e22-9037f933a01e">Y position of the Table Reference Point with respect to the Isocenter (mm).</para>
+                                        <para xml:id="para_d5d7133a-4e6c-4369-a10b-abf76f64d432">See <xref linkend="sect_C.8.19.6.13.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_de2459c2-a2ff-4b21-ac13-866d31a6c7d0">&gt;Table Z Position to Isocenter</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_16f43ccb-c46c-49e9-8a4e-6b0555238d72">(0018,9468)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_cc343a4e-d2b1-41a8-9d3c-1c047fd26999">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d86a5ae1-dec4-4d3d-b4f9-c0fb34e2b544">Z position of the Table Reference Point with respect to the Isocenter (mm).</para>
+                                        <para xml:id="para_66441433-bde2-4ae1-a955-e4a8e0fe4f29">See <xref linkend="sect_C.8.19.6.13.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_77e84075-b6d2-4fbd-96b9-12755a032e0c">&gt;Table Horizontal Rotation Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_5f0c7dd6-a78b-40c4-a25f-6c6ad1acf5d3">(0018,9469)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_397d6412-2006-49c3-a6b1-15f45b9b42c2">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_9a6c4b65-04d0-4887-a82a-ae9c784b4bc9">Rotation of the table in the horizontal plane.</para>
+                                        <para xml:id="para_00e2b6da-c0ab-4e0c-ac00-40d2c1bf964f">See <xref linkend="sect_C.8.19.6.13.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_cc65c7c7-7229-4902-846c-abd487717580">&gt;Table Head Tilt Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_f1ebe603-41a3-44cd-a0a0-4b746e4f3634">(0018,9470)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_b61244f7-f0a0-4144-8366-ea19a9ae3472">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1ed79f1f-4b2b-46d1-a80f-b2a42a9c9131">Angle of the head-feet axis of the table in degrees relative to the horizontal plane.</para>
+                                        <para xml:id="para_2ab71b50-cf74-4c5b-a172-7f53e49fac17">See <xref linkend="sect_C.8.19.6.13.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_ac2400c0-bcdf-4d94-a9b5-5d127e1efa50">&gt;Table Cradle Tilt Angle</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_de94db83-1410-40f9-a089-9a2100c7a934">(0018,9471)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_900205a6-c8eb-4090-8662-1563efbe107a">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_961f78f4-cf20-460b-abb9-e6c35a233d5e">Angle of the left-right axis of the table in degrees relative to the horizontal plane.</para>
+                                        <para xml:id="para_862b1263-8f48-44c4-9bc4-e50ed2b3be98">See <xref linkend="sect_C.8.19.6.13.1.3" xrefstyle="select: label"/> for further explanation.</para>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <section label="C.8.19.6.13.1" status="6" xml:id="sect_C.8.19.6.13.1">
+                            <title>Isocenter Reference System Attribute Description</title>
+                            <para xml:id="para_036d3f18-4377-41fa-8c8f-4880841b7398">The Isocenter Reference System Attributes describe the 3D geometry of the X-Ray equipment composed by the X-Ray positioner and the X-Ray table.</para>
+                            <para xml:id="para_7233983b-e779-45a7-8ae1-3370905a1dab">These Attributes define three coordinate systems in the 3D space:</para>
+                            <itemizedlist>
+                                <listitem>
+                                    <para xml:id="para_67ff9a35-382d-49ce-92f2-ae28aceb6297">Isocenter coordinate system</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_27cb6a5c-203f-4425-9d3f-99a4587d2fdb">Positioner coordinate system</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_ed146b29-2f91-43cd-8d5b-663419e26557">Table coordinate system</para>
+                                </listitem>
+                            </itemizedlist>
+                            <para xml:id="para_712a36bf-623f-480d-89e1-b3e2b02d897d">The Isocenter Reference System Attributes describe the relationship between the 3D coordinates of a point in the table coordinate system and the 3D coordinates of such point in the positioner coordinate system (both systems moving in the equipment), by using the Isocenter coordinate system that is fixed in the equipment.</para>
+                            <note>
+                                <para xml:id="para_a6ca6737-12e0-41cf-9349-15d7c0a071cc">
+                                    <olink targetdoc="PS3.17" targetptr="chapter_FFF" xrefstyle="template:Annex %n “%t” in PS3.17"/> describes the transformations necessary to transpose between coordinate systems.</para>
+                            </note>
+                            <section label="C.8.19.6.13.1.1" status="7" xml:id="sect_C.8.19.6.13.1.1">
+                                <title>Isocenter Coordinate System</title>
+                                <para xml:id="para_028be464-2eae-4c44-9d26-42b6c7eb5efc">The Isocenter coordinate system (O,X,Y,Z) of the equipment is defined as follows:</para>
+                                <itemizedlist>
+                                    <listitem>
+                                        <para xml:id="para_f0cfb727-3f93-4a65-b3dc-a9ce255af03e">Origin O is on the System Isocenter</para>
+                                    </listitem>
+                                    <listitem>
+                                        <para xml:id="para_79761690-319d-4c62-81df-6c4e98314f49">+Y DOWNWARD (gravity)</para>
+                                    </listitem>
+                                    <listitem>
+                                        <para xml:id="para_27621d4a-1df8-4bcb-b3e8-7e1fefbb07b7">+X, +Z directions in the horizontal plane (gravity plane). Directions arbitrarily defined by the manufacturer</para>
+                                    </listitem>
+                                </itemizedlist>
+                                <para xml:id="para_15f5b231-edd6-4b59-ab30-080550fa5126">
+                                    <figure label="C.8.19.6-4" pgwide="1" xml:id="figure_C.8.19.6-4">
+                                        <title>Isocenter Coordinate System</title>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6-4.svg"/>
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                            </section>
+                            <section label="C.8.19.6.13.1.2" status="7" xml:id="sect_C.8.19.6.13.1.2">
+                                <title>Positioner Coordinate System</title>
+                                <para xml:id="para_53b16557-d9f8-4afb-9b17-5797106e6d45">The Positioner Coordinate System (O<subscript>p</subscript>, X<subscript>p</subscript>, Y<subscript>p</subscript>, Z<subscript>p</subscript>) is defined as follows:</para>
+                                <itemizedlist>
+                                    <listitem>
+                                        <para xml:id="para_74060364-c9ce-4528-b16e-de220226b9ae">Origin O<subscript>p</subscript>, is the origin of the Isocenter coordinate system O</para>
+                                    </listitem>
+                                    <listitem>
+                                        <para xml:id="para_77889895-977a-4a7d-852b-8e224249bc41">X<subscript>p</subscript> axis is parallel to the horizontal scan-lines of the detector (rows). Positive direction from left to right of the detector plane looking towards the source.</para>
+                                    </listitem>
+                                    <listitem>
+                                        <para xml:id="para_796c6f18-c954-4b79-840c-2a2bf02d5c43">Z<subscript>p</subscript> axis is parallel to the vertical scan-lines of the detector (columns). Positive direction from bottom to top of the detector plane looking towards the source.</para>
+                                    </listitem>
+                                    <listitem>
+                                        <para xml:id="para_6b72e44c-1871-4b42-acd9-069282ccde46">Y<subscript>p</subscript> is the axis from the isocenter to the X-Ray source. Positive direction from the Isocenter to the X-Ray Source. This axis is so-called the X-Ray center beam.</para>
+                                    </listitem>
+                                </itemizedlist>
+                                <para xml:id="para_64a82c64-5e0e-434a-9cf7-569092a544dc">
+                                    <figure label="C.8.19.6-5" pgwide="1" xml:id="figure_C.8.19.6-5">
+                                        <title>Positioner Coordinate System</title>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6-5.svg"/>
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                                <note>
+                                    <para xml:id="para_c2d325c2-c109-4d1d-bd15-2fda30ad974a">The quantities SID and ISO are specified by the Attributes Distance Source to Detector (0018,1110) and Distance Source to Isocenter (0018,9402) respectively.</para>
+                                </note>
+                                <para xml:id="para_53a2ae2a-05b1-46a9-99ca-3fa3735365b0">The Positioner Coordinate System (O<subscript>p</subscript>, X<subscript>p</subscript>, Y<subscript>p</subscript>, Z<subscript>p</subscript>) is characterized, with respect to the Isocenter Coordinate System (O, X, Y, Z), by two angles describing the X-Ray center beam, and a third angle describing the rotation of the X-Ray detector plane. These angles are relative to the Isocenter reference system, and independent from the patient position on the equipment.</para>
+                                <para xml:id="para_34be9871-5434-434a-a2a2-225a8dc5b0da">Positioner Isocenter Primary Angle (0018,9463) (so-called Ap<subscript>1</subscript> in <xref linkend="figure_C.8.19.6-6" xrefstyle="select: label"/>) is defined in the plane XY, as the angle between the plane YZ and the plane Y<subscript>p</subscript>Z. The axis of rotation of this angle is the Z axis. Angle from -Y to +X is positive. The valid range of this angle is -180 to +180 degrees.</para>
+                                <para xml:id="para_0d1a0b73-5081-4023-886f-a72aa28b838c">Positioner Isocenter Secondary Angle (0018,9464) (so-called Ap<subscript>2</subscript> in <xref linkend="figure_C.8.19.6-6" xrefstyle="select: label"/>) is defined in the plane Y<subscript>p</subscript>Z, as the angle of the X-Ray Center Beam (i.e., Y<subscript>p</subscript>) relative to the XY plane. The axis of rotation of this angle is perpendicular to the plane Y<subscript>p</subscript>Z. Angle from the plane XY to +Z is positive. The valid range of this angle is -180 to +180 degrees.</para>
+                                <para xml:id="para_00ff6941-b2d0-4fd3-bd1a-18d604c59345">Positioner Isocenter Detector Rotation Angle (0018,9465) (so-called Ap<subscript>3</subscript> in <xref linkend="figure_C.8.19.6-6" xrefstyle="select: label"/> and in <xref linkend="figure_C.8.19.6-7" xrefstyle="select: label"/>) is defined in the detector plane, as the angle of the vertical scan-lines of the detector (i.e., Z<subscript>p</subscript>) relative to the intersection between the detector plane and the plane Y<subscript>p</subscript>Z. The sign of this angle is positive clockwise when facing on to the detector plane (see <xref linkend="figure_C.8.19.6-7" xrefstyle="select: label"/>). The valid range of this angle is -180 to +180 degrees.</para>
+                                <para xml:id="para_5571e0e9-1e30-408e-bfee-1b817f9b2d13">
+                                    <figure label="C.8.19.6-6" pgwide="1" xml:id="figure_C.8.19.6-6">
+                                        <title>Positioner Isocenter Angles</title>
+                                        <!--<mediaobject>
+                      <imageobject>
+                        <imagedata fileref="part03_fromword_files/C_8_19_6_6.png"/>
+                      </imageobject>
+                    </mediaobject>
+                    -->
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6-6.svg"/>
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                                <para xml:id="para_5f19ca7d-5d0f-4ed8-9710-ddf3c8dd5de5">
+                                    <figure label="C.8.19.6-7" pgwide="1" xml:id="figure_C.8.19.6-7">
+                                        <title>Positioner Isocenter Detector Rotation Angle when Ap<subscript>1</subscript> = 0 and Ap<subscript>2</subscript> = 0</title>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6-7.svg"/>
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                            </section>
+                            <section label="C.8.19.6.13.1.3" status="7" xml:id="sect_C.8.19.6.13.1.3">
+                                <title>Table Coordinate System</title>
+                                <para xml:id="para_000fc22a-5c48-403a-b764-65fdafd187e1">The table coordinate system (O<subscript>t</subscript>, X<subscript>t</subscript>, Y<subscript>t</subscript>, Z<subscript>t</subscript>) is defined as follows:</para>
+                                <para xml:id="para_bb570809-ec04-43ab-83c5-aa44be7b493f">- Origin O<subscript>t</subscript>, so-called Table Reference Point, is on the Table Top plane</para>
+                                <para xml:id="para_07164004-18eb-42f9-86a7-303bccc86468">- +X<subscript>t</subscript> direction to the TABLE LEFT</para>
+                                <para xml:id="para_d2a24efd-414a-4ae2-87d8-50e3035f6639">- +Z<subscript>t</subscript> direction to the TABLE HEAD</para>
+                                <para xml:id="para_541d1d46-37f9-4bf2-a8f9-eca8fb8645ac">- +Y<subscript>t</subscript> direction to the TABLE DOWN</para>
+                                <para xml:id="para_ac85c038-28d0-4ee8-a240-3dc7219e4954">The table coordinate system (O<subscript>t</subscript>, X<subscript>t</subscript>, Y<subscript>t</subscript>, Z<subscript>t</subscript>) is characterized, with respect to the Isocenter coordinate system (O, X, Y, Z), by a 3D translation and 3 angles describing the tilting and rotation:</para>
+                                <para xml:id="para_3dd52bbf-f8ad-4cc4-a814-57060aaaa162">
+                                    <emphasis role="bold">Table X Position to Isocenter</emphasis>
+                                    <emphasis role="bold">(0018,9466)</emphasis> (so-called <emphasis role="bold">T<subscript>X</subscript>
+                                    </emphasis> in <xref linkend="figure_C.8.19.6-8" xrefstyle="select: label"/>) is defined as the translation of the Table Reference Point O<subscript>t</subscript> with respect to the Isocenter Coordinate System in the X direction. Table motion toward +X is positive.</para>
+                                <para xml:id="para_4d507788-6c65-485e-8ddc-96448d389f26">
+                                    <emphasis role="bold">Table Y Position to Isocenter</emphasis>
+                                    <emphasis role="bold">(0018,9467)</emphasis> (so-called <emphasis role="bold">T<subscript>Y</subscript>
+                                    </emphasis> in <xref linkend="figure_C.8.19.6-8" xrefstyle="select: label"/>) is defined as the translation of the Table Reference Point O<subscript>t</subscript> with respect to the Isocenter Coordinate System in the Y direction. Table motion toward +Y is positive.</para>
+                                <para xml:id="para_98277c0a-0761-4606-9ab1-458ef78a55b6">
+                                    <emphasis role="bold">Table Z Position to Isocenter</emphasis>
+                                    <emphasis role="bold">(0018,9468)</emphasis> (so-called <emphasis role="bold">T<subscript>Z</subscript>
+                                    </emphasis> in <xref linkend="figure_C.8.19.6-8" xrefstyle="select: label"/>) is defined as the translation of the Table Reference Point O<subscript>t</subscript> with respect to the Isocenter Coordinate System in the Z direction. Table motion toward +Z is positive.</para>
+                                <note>
+                                    <para xml:id="para_b1eb01f1-ff13-4c04-a814-d7f8d7141bb0">A translation of ( <emphasis role="bold">T<subscript>X</subscript>,T<subscript>Y</subscript>,T<subscript>Z</subscript>
+                                        </emphasis>) = (0, 0, 0) means that the Table Reference Point O<subscript>t</subscript> is at the System Isocenter.</para>
+                                </note>
+                                <para xml:id="para_fd2e92fd-5372-4579-8d9c-f5d2da4c33bf">
+                                    <emphasis role="bold">Table Horizontal Rotation Angle</emphasis> (so-called <emphasis role="bold">At<subscript>1</subscript>
+                                    </emphasis> in <xref linkend="figure_C.8.19.6-9" xrefstyle="select: label"/>) is defined in the horizontal plane XZ, as the angle of the projection of the +Zt axis in the XZ plane relative to the +Z axis. The axis of rotation of this angle is the vertical axis crossing the Table Reference Point Ot. Zero value is defined when the projection of +Zt in the XZ plane is equal to +Z. Angle from +Z to +X is positive. The valid range of this angle is -180 to +180 degrees.</para>
+                                <para xml:id="para_a13733bb-85b0-4f4b-800f-97646dcb1ec9">
+                                    <emphasis role="bold">Table Head Tilt Angle</emphasis> (so-called <emphasis role="bold">At<subscript>2</subscript>
+                                    </emphasis> in <xref linkend="figure_C.8.19.6-9" xrefstyle="select: label"/>) is defined in the vertical plane containing Z<subscript>t</subscript> (i.e., YZ<subscript>t</subscript>), as the angle of the +Z<subscript>t</subscript> axis relative to the horizontal plane XZ. The axis of rotation of this angle is defined as the intersection between the horizontal plane XZ and the plane X<subscript>t</subscript>Y<subscript>t</subscript>. Zero value is defined when +Z<subscript>t</subscript> is contained in the horizontal plane XZ. Angle from horizontal (plane XZ) to -Y direction (upwards) is positive, indicating that the head of the table is above the horizontal plane. The valid range of this angle is -45 to +45 degrees.</para>
+                                <para xml:id="para_1918cc2a-5691-421e-b004-da3eab2a007b">
+                                    <emphasis role="bold">Table Cradle</emphasis>
+                                    <emphasis role="bold">Tilt Angle</emphasis> (so-called <emphasis role="bold">At<subscript>3</subscript>
+                                    </emphasis> in <xref linkend="figure_C.8.19.6-9" xrefstyle="select: label"/>) is defined in the X<subscript>t</subscript>Y<subscript>t</subscript> plane, as the angle of the +X<subscript>t</subscript> axis relative to the intersection between the X<subscript>t</subscript>Y<subscript>t</subscript> plane and the horizontal plane XZ. The axis of rotation of this angle is the axis Z<subscript>t</subscript>. Zero value is defined when +X<subscript>t</subscript> is contained in the horizontal plane XZ. Angle from horizontal (plane XZ) to -Y direction (upwards) is positive, indicating that the left of the table is above the horizontal plane. The valid range of this angle is -45 to +45 degrees.</para>
+                                <note>
+                                    <para xml:id="para_87fd7a58-e7dc-4888-8b25-8f333e0038e9">The angles <emphasis role="bold">At<subscript>1</subscript>
+                                        </emphasis>, <emphasis role="bold">At<subscript>2</subscript>
+                                        </emphasis> and <emphasis role="bold">At<subscript>3</subscript>
+                                        </emphasis> are independent from any specific mechanical design of the table rotation axis defined by a manufacturer. In particular, they don't require the three rotation axis to cross on a single point. If a mechanical rotation axis does not cross the Table Reference Point O<subscript>t</subscript>, a mechanical rotation around this axis will generate a change in one or more table angles as well as a translation of the Table Reference Point.</para>
+                                </note>
+                                <para xml:id="para_fbbdd6df-1eec-4a14-ad44-c39f7c43b7f2">
+                                    <figure label="C.8.19.6-8" pgwide="1" xml:id="figure_C.8.19.6-8">
+                                        <title>Table Translation with respect to the Isocenter Reference System</title>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6-8.svg"/>
+                                                <!--<imagedata fileref="part03_fromword_files/C.C_8_19_6-8.png"/>-->
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                                <para xml:id="para_600eebf1-37ad-4b90-a966-cf9120451b48">
+                                    <figure label="C.8.19.6-9" pgwide="1" xml:id="figure_C.8.19.6-9">
+                                        <title>Table Angulations with respect to the Isocenter Reference System</title>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="figures/PS3.3_C.8.19.6-9.svg"/>
+                                                <!--<imagedata fileref="part03_fromword_files/C_8_19_6-9.png"/>-->
+                                            </imageobject>
+                                        </mediaobject>
+                                    </figure>
+                                </para>
+                            </section>
+                        </section>
+                        <section label="C.8.19.6.13.2" status="6" xml:id="sect_C.8.19.6.13.2">
+                            <title>Relationship Patient Coordinate System</title>
+                            <para xml:id="para_f967274d-5a7c-4b0d-8404-13f24e602be3">The Isocenter Reference System Attributes allow expressing the positioner angulations (i.e., X-Ray Center Beam direction) as a vector in the table coordinate system. If the relationship between the X-Ray table and the patient is known, it is possible to express any vector of the table coordinate system as a direction in the patient.</para>
+                            <para xml:id="para_a806a5c8-a48e-47cc-b1f9-1c6998c84173">Therefore, the Isocenter Reference System Attributes allow calculating the positioner angulations in the Patient-Based Coordinate System if the following Attributes are present:</para>
+                            <itemizedlist>
+                                <listitem>
+                                    <para xml:id="para_7280b5bf-d1ab-4484-a7f7-b29b4bb3d2a7">Patient Orientation Code Sequence (0054,0410)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_7aa607dd-b3c2-45bd-93f5-d288207311a7">Patient Orientation Modifier Code Sequence (0054,0412)</para>
+                                </listitem>
+                            </itemizedlist>
+                            <para xml:id="para_db7ba7fb-aabf-4c78-aed4-e50077bf2765">Further, the Isocenter Reference System Attributes allow calculating the patient anatomical directions (i.e., left, right, head, feet, anterior, posterior) of the rows and columns of the stored image, if the following Attributes are present:</para>
+                            <itemizedlist>
+                                <listitem>
+                                    <para xml:id="para_2d72591c-09af-406c-98fe-e79497541495">Patient Orientation Code Sequence (0054,0410)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_5bd124da-75bb-429d-b2aa-58c720ae9721">Patient Orientation Modifier Code Sequence (0054,0412)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_77552657-ef15-4138-92c3-b2797252585d">Field of View Rotation (0018,7032)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_fe63b36d-908b-455d-a6f3-de5c152728e0">Field of View Horizontal Flip (0018,7034)</para>
+                                </listitem>
+                            </itemizedlist>
+                            <para xml:id="para_1637736e-a4c9-4725-9fee-5971f5129963">For registration purposes, a given point fixed in the patient (object of interest) that is defined in the table coordinate system can be expressed as row and column coordinates of the stored image if the relationship between the positioner coordinate system and the stored image is fully characterized. Therefore, the Isocenter Reference System Attributes allow calculating the projection of a point of the patient as row and column coordinates of the stored image, if the following Attributes are present:</para>
+                            <itemizedlist>
+                                <listitem>
+                                    <para xml:id="para_f7aea56b-f65b-4261-b45d-f8ad104402eb">Frame of Reference UID (0020,0052) and must be equal for all images involved in the registration</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_7ae249d6-57dd-493c-a10e-4e71192caa15">Field of View Rotation (0018,7032)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_c8752166-50e5-4bab-aeba-a70002792074">Field of View Horizontal Flip (0018,7034)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_9acc4b42-806b-4827-bee4-fc0067d4981d">Imager Pixel Spacing (0018,1164)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_6ab75043-ba83-46bd-bcc4-4ae59d3d6881">Distance Source to Isocenter (0018,9402)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_2e1cb5b2-ed3f-4bc3-b8cc-62cb7738ecab">Distance Source to Detector (0018,1110)</para>
+                                </listitem>
+                            </itemizedlist>
+                            <para xml:id="para_57f16c2b-0d6e-48ca-b5c2-21b6cc825120">In addition for a system equipped with a digit al detector the following Attributes need to be present:</para>
+                            <itemizedlist>
+                                <listitem>
+                                    <para xml:id="para_c8cca806-275b-42dd-8d71-4d4b4c91464d">Detector Element Spacing (0018,7022)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_bfde9b40-dd04-430b-ba10-cc68e8df6d61">Field of view Origin (0018,7030)</para>
+                                </listitem>
+                                <listitem>
+                                    <para xml:id="para_e34cd631-67b3-48e8-b932-f1a6f1ddaa4c">Position of Isocenter Projection (0018,9430)</para>
+                                </listitem>
+                            </itemizedlist>
+                        </section>
+                    </section>
+                    <section label="C.8.19.6.14" status="5" xml:id="sect_C.8.19.6.14">
+                        <title>X-Ray Geometry Macro</title>
+                        <para xml:id="para_f2b8a185-a1e6-4ce6-a52b-db863ed33d8c">
+                            <xref linkend="table_C.8.19.6-14" xrefstyle="select: label"/> specifies the Attributes containing the X-Ray Geometry Functional Group Macro.</para>
+                        <table frame="box" label="C.8.19.6-14" rules="all" xml:id="table_C.8.19.6-14">
+                            <caption>X-Ray Geometry Macro Attributes</caption>
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_cd03287c-1a79-4263-888b-502062c57256">Attribute Name</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_e65141f7-a562-4dc5-a2fe-22ed227f8762">Tag</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_9cd21824-b3c3-4cb6-8393-b380b047ed77">Type</para>
+                                    </th>
+                                    <th align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_d8b84fc8-4467-430f-baa4-2c7dbec8f82f">Attribute Description</para>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_11c18f5f-7a5f-4c23-ba85-457e640a7873">X-Ray Geometry Sequence</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_23c38f86-1951-4158-83a8-39961234a646">(0018,9476)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_eebf5042-9014-476c-a4d9-e21ec39660cc">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1bec8807-3202-49c1-bc9f-f4e9c4c73493">Sequence containing the geometric properties for this frame.</para>
+                                        <para xml:id="para_b6ce5112-36e6-47e1-9013-3aa7123e173c">Only a single Item shall be included in this Sequence.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_7d774ca4-acf4-45b3-ab53-e9b4132ddce1">&gt;Distance Source to Isocenter</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_3b56d5cf-d647-4368-93ed-62f0e3dda6cb">(0018,9402)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_06792307-5413-4650-9a97-c2edfab7062e">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_d2a5ba29-aed7-48b8-9356-04445b72a30f">Distance from source to isocenter in mm.</para>
+                                    </td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_1245da37-fd2e-4e60-a3f8-8a5037d51f58">&gt;Distance Source to Detector</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_04c4a4d2-893b-49e0-b07d-c66ebebc8645">(0018,1110)</para>
+                                    </td>
+                                    <td align="center" colspan="1" rowspan="1">
+                                        <para xml:id="para_98d91204-1d33-4ac4-afd8-f8a7c316dc28">1</para>
+                                    </td>
+                                    <td align="left" colspan="1" rowspan="1">
+                                        <para xml:id="para_4b3f8abe-5fd5-45ec-9a67-ac1d470b6edb">Distance from source to receptor plane perpendicular to the receptor plane in mm.</para>
+                                        <note>
+                                            <para xml:id="para_9e71ba0e-7cdb-43ee-b98b-50f38260868b">This value is traditionally referred to as Source Image Receptor Distance (SID).</para>
+                                        </note>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                </section>
+                <section label="C.8.19.7" status="4" xml:id="sect_C.8.19.7">
+                    <title>XA/XRF Multi-frame Presentation Module</title>
+                    <para xml:id="para_a27fc2f4-02aa-4145-8bf3-732fa2d13503">
+                        <xref linkend="table_C.8.19.7-1" xrefstyle="select: label"/> specifies the Attributes of a XA/XRF Multi-frame Presentation Module.</para>
+                    <table frame="box" label="C.8.19.7-1" rules="all" xml:id="table_C.8.19.7-1">
+                        <caption>XA/XRF Multi-frame Presentation Module Attributes</caption>
+                        <thead>
+                            <tr valign="top">
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_055edcbd-5e7b-44df-b63f-479e19646ad4">Attribute Name</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_962215fc-d45c-479d-89dd-4f26dee3adcd">Tag</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_087c5cf3-08a9-47b1-bfff-0908e6abfdde">Type</para>
+                                </th>
+                                <th align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_69cee351-8c46-42d4-8f50-bd4b276482f6">Attribute Description</para>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_f6227d2b-3b95-46c0-971b-77a590263a30">Preferred Playback Sequencing</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_97d07ce9-0623-4fde-95a1-9f33dc5ed0e4">(0018,1244)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_234887e5-7d09-4480-9362-db3f159c9179">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_1d60b7ed-8b25-4c9b-a10f-d29724d34925">Describes the preferred playback sequencing for a multi-frame image.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Enumerated Values:</title>
+                                        <varlistentry>
+                                            <term>0</term>
+                                            <listitem>
+                                                <para xml:id="para_22aab80e-db33-43a8-877b-c6a875748dc3">Looping (1,2…n,1,2,…n,1,2,….n,…)</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>1</term>
+                                            <listitem>
+                                                <para xml:id="para_b17e28d0-aaca-4575-91c6-b24e0c42d0f5">Sweeping (1,2,…n,n -1,…2,1,2,…n,…)</para>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_294ab339-2f8a-4d53-813d-a125397e1aa6">Frame Display Sequence</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_0a518f40-80df-4d71-b155-529a91f5a0e5">(0008,9458)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_56ced438-ecab-4ea6-8d79-0a0bd89d2722">3</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_dec70741-1d00-48f7-8468-50e755fc1912">Sequence that specifies the display frame rate of a selected set of frames. The Items are ordered in increasing frame number. The range of the frames may not overlap and the ranges shall be adjacent.</para>
+                                    <para xml:id="para_d3f60a1c-01c2-4c37-9c5b-e888b65fcd53">One or more Items are permitted in this Sequence.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2a2bf6ef-4c17-480d-9a24-0f9a0b5571df">&gt;Start Trim</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f9d44505-6d0a-457d-8658-207187f59520">(0008,2142)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_8ccfe9de-431b-4167-8fad-c40e2d412d2e">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_13ded7b7-46c1-49b3-973e-df7dabbe276e">The Frame Number of the first frame of the set of frames to be displayed in this Item.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_345e46ef-b75d-456c-9f9e-919d5658b0aa">&gt;Stop Trim</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_84c0ef44-e8be-4207-86d2-dc644429c27f">(0008,2143)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_23118ecc-8060-4af4-8b27-f915ea0e86b3">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_2b420eb4-e454-4a45-807a-129cde8853c9">The Frame Number of the last frame of the set of frames to be displayed in this Item.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_0f79fb10-0db9-410d-a92b-59340363e16e">&gt;Skip Frame Range Flag</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f655608d-dc6f-4f0a-864d-87f63c9d55a4">(0008,9460)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_5fc4c128-db93-4848-902a-1db4a2947a38">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_654c6e82-ec5f-4673-8b26-fc375ca19060">A flag indicating that the range of frames in this Item may be skipped.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>DISPLAY</term>
+                                            <listitem>
+                                                <para xml:id="para_fa555605-809f-47e2-8cb7-2d833c34acf1"/>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>SKIP</term>
+                                            <listitem>
+                                                <para xml:id="para_138191f9-47d1-4c30-8001-0ed7aaf6dbf8"/>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_35801ce6-5edd-46b1-a2fa-df972df38ff3">&gt;Recommended Display Frame Rate in Float</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_120407e4-103c-4125-bdfa-a5f27ea4175e">(0008,9459)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_b036bfc7-bf03-4fa8-86e8-3db62e899e31">1</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_795a6a5d-df2d-4dc3-86e7-5254327143af">Recommended rate at which the frames of this Item should be displayed in frames/second.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_fd276a19-c4e2-4a65-951e-2f3344f2cdfd">&gt;Recommended Viewing Mode</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_71a7072f-7038-44b5-89a7-777251647878">(0028,1090)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_34cb1a33-75b7-4719-8513-ea2ec895a639">2</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_20643093-6712-4b21-b894-f5296a860750">Specifies the recommended viewing protocol(s).</para>
+                                    <para xml:id="para_a0bb3133-dc71-4b7d-9c21-f4ef24336a6c">When this Attribute is present with a value, this value shall override the value of Recommended Viewing Mode (0028,1090) specified in the <xref linkend="sect_C.7.6.10" xrefstyle="select: title"/>.</para>
+                                    <variablelist spacing="compact">
+                                        <title>Defined Terms:</title>
+                                        <varlistentry>
+                                            <term>SUB</term>
+                                            <listitem>
+                                                <para xml:id="para_9c9ae79d-e291-4484-a04c-efd829556b87">subtraction with mask images</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term>NAT</term>
+                                            <listitem>
+                                                <para xml:id="para_f245bfc6-bf31-4ffc-8486-182833cd7503">native viewing of image as stored</para>
+                                            </listitem>
+                                        </varlistentry>
+                                    </variablelist>
+                                    <note>
+                                        <para xml:id="para_7bbe0e5b-5227-4c89-8c42-9bb601d70354">If an implementation does not recognize the Defined Term for Recommended Viewing Mode (0028,1090), reverting to native display mode is recommended.</para>
+                                    </note>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_b8ea6318-780f-41ab-a59c-f6f5dbda72ca">&gt;Display Filter Percentage</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_f0cb82ba-d677-486f-9d02-aa5f3ced6843">(0028,9411)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_647a0dd7-91e0-4a09-b74b-8510a0e78650">2</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_e67ce6fe-15e2-4145-af02-da13e9e46182">Edge enhancement filter percentage that is recommended by the pixel data creator as filter presetting for display purposes. The value of 100 corresponds to the maximum filter strength that can be applied by a specific application displaying the image.</para>
+                                </td>
+                            </tr>
+                            <tr valign="top">
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_c1298d9e-254f-49d7-a10b-bd180af698a1">&gt;Mask Visibility Percentage</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_6bbdbffb-507b-4991-9151-a44e02b80e6d">(0028,9478)</para>
+                                </td>
+                                <td align="center" colspan="1" rowspan="1">
+                                    <para xml:id="para_a189b907-10fe-4963-ad79-2b7f019ddf34">1C</para>
+                                </td>
+                                <td align="left" colspan="1" rowspan="1">
+                                    <para xml:id="para_fc09b6f8-1003-4fe4-a78b-db91c4710e38">The percentage of visibility of the mask frame during a subtracted display. A value of 0 corresponds to subtracted display, a value of 100 corresponds to un-subtracted display (native). See <xref linkend="sect_C.8.19.7.1" xrefstyle="select: label"/>.</para>
+                                    <note>
+                                        <para xml:id="para_08dbf217-226f-43a3-9edf-b23e10f20706">The value of 100 is equivalent to Recommended Viewing Mode (0028,1090) having a value of NAT.</para>
+                                    </note>
+                                    <para xml:id="para_2c65f582-5b5f-46e2-812d-1d4c5762a07b">Required if Recommended Viewing Mode (0028,1090) equals SUB.</para>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <section label="C.8.19.7.1" status="5" xml:id="sect_C.8.19.7.1">
+                        <title>Multi-frame Presentation Attributes</title>
+                        <section label="C.8.19.7.1.1" status="6" xml:id="sect_C.8.19.7.1.1">
+                            <title>Mask Visibility Percentage (Informative)</title>
+                            <para xml:id="para_507c7ef6-9309-4b0c-9618-b60fad97e91a">An example of the usage of the Mask Visibility Percentage (0028,9478) Attribute is illustrated below.</para>
+                            <para xml:id="para_b8f626ae-0d86-4db4-a098-34240496003e">Assume that P<subscript>sub</subscript> is the output pixel level of a subtracted frame, its calculation can be expressed as followed:</para>
+                            <para xml:id="para_9ba9fbad-0208-4bc3-90b2-bbcdf49bd789">P<subscript>contrast</subscript>: Pixel level of the contrast frame in the logarithmic domain</para>
+                            <para xml:id="para_19097afd-4c88-4900-83bb-0c87cfeb2a28">P<subscript>mask</subscript>: Pixel level of the mask frame in the logarithmic domain</para>
+                            <para xml:id="para_00281965-6cd8-4266-a8f4-a258c71d1a08">X: Mask Visibility Percentage (0028,9478): 0 &lt;= X &lt;= 100</para>
+                            <para xml:id="para_0665a389-2c3a-4eae-bddc-e8272811fc51">P<subscript>sub</subscript> = P<subscript>contrast</subscript>- (1- X/100) * P<subscript>mask</subscript>
+                            </para>
+                        </section>
+                    </section>
+                </section>
+            </section>
     </section>
     <section label="C.9" status="2" xml:id="sect_C.9">
       <title>Overlays</title>

--- a/dicom_validator/tests/fixtures/2021d/json/iod_info.json
+++ b/dicom_validator/tests/fixtures/2021d/json/iod_info.json
@@ -1,5 +1,220 @@
 {
   "1.2.840.10008.5.1.4.1.1.12.1.1": {
+    "group_macros": {
+      "Cardiac Synchronization": {
+        "ref": "C.7.6.16.2.7",
+        "use": "U"
+      },
+      "Contrast/Bolus Usage": {
+        "cond": {
+          "type": "U"
+        },
+        "ref": "C.7.6.16.2.12",
+        "use": "C - Required if the is present."
+      },
+      "Derivation Image": {
+        "cond": {
+          "type": "U"
+        },
+        "ref": "C.7.6.16.2.6",
+        "use": "C - Required if the image or frame has been derived from another SOP Instance."
+      },
+      "Frame Anatomy": {
+        "ref": "C.7.6.16.2.8",
+        "use": "M"
+      },
+      "Frame Content": {
+        "ref": "C.7.6.16.2.2",
+        "use": "M"
+      },
+      "Frame Display Shutter": {
+        "ref": "C.7.6.16.2.16",
+        "use": "U"
+      },
+      "Frame Pixel Shift": {
+        "ref": "C.7.6.16.2.14",
+        "use": "U"
+      },
+      "Frame VOI LUT": {
+        "ref": "C.7.6.16.2.10",
+        "use": "M"
+      },
+      "Irradiation Event Identification": {
+        "ref": "C.7.6.16.2.18",
+        "use": "M"
+      },
+      "Patient Orientation in Frame": {
+        "cond": {
+          "index": 0,
+          "op": "=",
+          "tag": "(0018,9474)",
+          "type": "MU",
+          "values": [
+            "YES"
+          ]
+        },
+        "ref": "C.7.6.16.2.15",
+        "use": "C - Required if C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise."
+      },
+      "Pixel Intensity Relationship LUT": {
+        "cond": {
+          "index": 0,
+          "op": "=",
+          "tag": "(0028,1040)",
+          "type": "MU",
+          "values": [
+            "LOG"
+          ]
+        },
+        "ref": "C.7.6.16.2.13",
+        "use": "C - Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise."
+      },
+      "Referenced Image": {
+        "ref": "C.7.6.16.2.5",
+        "use": "U"
+      },
+      "Respiratory Synchronization": {
+        "ref": "C.7.6.16.2.17",
+        "use": "U"
+      },
+      "X-Ray Calibration Device Usage": {
+        "ref": "C.8.19.6.6",
+        "use": "U"
+      },
+      "X-Ray Collimator": {
+        "cond": {
+          "index": 0,
+          "op": "=",
+          "tag": "(0008,0008)",
+          "type": "MU",
+          "values": [
+            "ORIGINAL"
+          ]
+        },
+        "ref": "C.8.19.6.12",
+        "use": "C - Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise."
+      },
+      "X-Ray Exposure Control Sensing Regions": {
+        "ref": "C.8.19.6.3",
+        "use": "U"
+      },
+      "X-Ray Field of View": {
+        "cond": {
+          "index": 0,
+          "op": "+",
+          "tag": "(0018,9462)",
+          "type": "MU"
+        },
+        "ref": "C.8.19.6.2",
+        "use": "C - Required if Isocenter Reference System Sequence (0018,9462) is present. May be present otherwise."
+      },
+      "X-Ray Frame Acquisition": {
+        "ref": "C.8.19.6.8",
+        "use": "U"
+      },
+      "X-Ray Frame Characteristics": {
+        "ref": "C.8.19.6.1",
+        "use": "U"
+      },
+      "X-Ray Frame Detector Parameters": {
+        "cond": {
+          "index": 0,
+          "op": "=",
+          "tag": "(0018,9420)",
+          "type": "MN",
+          "values": [
+            "DIGITAL_DETECTOR"
+          ]
+        },
+        "ref": "C.8.19.6.5",
+        "use": "C - Required if X-Ray Receptor Type (0018,9420) is present and equals DIGITAL_DETECTOR."
+      },
+      "X-Ray Frame Pixel Data Properties": {
+        "ref": "C.8.19.6.4",
+        "use": "M"
+      },
+      "X-Ray Geometry": {
+        "cond": {
+          "index": 0,
+          "op": "+",
+          "tag": "(0018,9401)",
+          "type": "MU"
+        },
+        "ref": "C.8.19.6.14",
+        "use": "C - Required if Projection Pixel Calibration Sequence (0018,9401) is present. May be present otherwise."
+      },
+      "X-Ray Isocenter Reference System": {
+        "ref": "C.8.19.6.13",
+        "use": "U"
+      },
+      "X-Ray Object Thickness": {
+        "ref": "C.8.19.6.7",
+        "use": "U"
+      },
+      "X-Ray Positioner": {
+        "cond": {
+          "and": [
+            {
+              "index": 0,
+              "op": "=",
+              "tag": "(0008,0008)",
+              "values": [
+                "ORIGINAL"
+              ]
+            },
+            {
+              "index": 0,
+              "op": "=",
+              "tag": "(0018,9474)",
+              "values": [
+                "YES"
+              ]
+            }
+          ],
+          "type": "MU"
+        },
+        "ref": "C.8.19.6.10",
+        "use": "C - Required if Image Type (0008,0008) Value 1 equals ORIGINAL and C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise."
+      },
+      "X-Ray Projection Pixel Calibration": {
+        "cond": {
+          "index": 0,
+          "op": "=",
+          "tag": "(0018,9474)",
+          "type": "MN",
+          "values": [
+            "YES"
+          ]
+        },
+        "ref": "C.8.19.6.9",
+        "use": "C - Required if C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES."
+      },
+      "X-Ray Table Position": {
+        "cond": {
+          "and": [
+            {
+              "index": 0,
+              "op": "=",
+              "tag": "(0008,0008)",
+              "values": [
+                "ORIGINAL"
+              ]
+            },
+            {
+              "index": 0,
+              "op": "=",
+              "tag": "(0018,9474)",
+              "values": [
+                "YES"
+              ]
+            }
+          ],
+          "type": "MU"
+        },
+        "ref": "C.8.19.6.11",
+        "use": "C - Required if Image Type (0008,0008) Value 1 equals ORIGINAL and C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise."
+      }
+    },
     "modules": {
       "Acquisition Context": {
         "ref": "C.7.6.14",
@@ -117,6 +332,7 @@
     "title": "Enhanced X-Ray Angiographic Image IOD"
   },
   "1.2.840.10008.5.1.4.1.1.2": {
+    "group_macros": {},
     "modules": {
       "CT Image": {
         "ref": "C.8.2.1",
@@ -205,6 +421,7 @@
     "title": "Computed Tomography Image IOD"
   },
   "1.2.840.10008.5.1.4.1.1.481.2": {
+    "group_macros": {},
     "modules": {
       "Clinical Trial Series": {
         "ref": "C.7.3.2",

--- a/dicom_validator/tests/fixtures/2021d/json/module_info.json
+++ b/dicom_validator/tests/fixtures/2021d/json/module_info.json
@@ -748,6 +748,29 @@
       "type": "1"
     }
   },
+  "10-5": {
+    "(0008,2218)": {
+      "items": {
+        "(0008,2220)": {
+          "items": {
+            "include": [
+              "8.8-1"
+            ]
+          },
+          "name": "Anatomic Region Modifier Sequence",
+          "type": "3"
+        },
+        "include": [
+          "8.8-1"
+        ]
+      },
+      "name": "Anatomic Region Sequence",
+      "type": "1"
+    },
+    "include": [
+      "10-8"
+    ]
+  },
   "10-7": {
     "(0008,2218)": {
       "items": {
@@ -3395,12 +3418,20 @@
       "type": "3"
     },
     "(5200,9229)": {
-      "items": {},
+      "items": {
+        "include": [
+          "FuncGroup"
+        ]
+      },
       "name": "Shared Functional Groups Sequence",
       "type": "1"
     },
     "(5200,9230)": {
-      "items": {},
+      "items": {
+        "include": [
+          "FuncGroup"
+        ]
+      },
       "name": "Per-frame Functional Groups Sequence",
       "type": "1"
     }
@@ -3573,6 +3604,507 @@
       },
       "name": "Real World Value Slope",
       "type": "1C"
+    }
+  },
+  "C.7.6.16.2.2": {
+    "(0020,9111)": {
+      "items": {
+        "(0018,9074)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Frame Acquisition DateTime",
+          "type": "1C"
+        },
+        "(0018,9151)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Frame Reference DateTime",
+          "type": "1C"
+        },
+        "(0018,9214)": {
+          "name": "Respiratory Cycle Position",
+          "type": "3"
+        },
+        "(0018,9220)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Frame Acquisition Duration",
+          "type": "1C"
+        },
+        "(0018,9236)": {
+          "name": "Cardiac Cycle Position",
+          "type": "3"
+        },
+        "(0020,9056)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0008,0016)",
+            "type": "MU",
+            "values": [
+              "1.2.840.10008.5.1.4.1.1.130"
+            ]
+          },
+          "name": "Stack ID",
+          "type": "1C"
+        },
+        "(0020,9057)": {
+          "cond": {
+            "or": [
+              {
+                "index": 0,
+                "op": "+",
+                "tag": "(0020,9056)"
+              },
+              {
+                "index": 0,
+                "op": "+",
+                "tag": "(0018,9621)"
+              }
+            ],
+            "type": "MN"
+          },
+          "name": "In-Stack Position Number",
+          "type": "1C"
+        },
+        "(0020,9128)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0008,0016)",
+            "type": "MU",
+            "values": [
+              "1.2.840.10008.5.1.4.1.1.130"
+            ]
+          },
+          "name": "Temporal Position Index",
+          "type": "1C"
+        },
+        "(0020,9156)": {
+          "name": "Frame Acquisition Number",
+          "type": "3"
+        },
+        "(0020,9157)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Dimension Index Values",
+          "type": "1C"
+        },
+        "(0020,9158)": {
+          "name": "Frame Comments",
+          "type": "3"
+        },
+        "(0020,9453)": {
+          "name": "Frame Label",
+          "type": "3"
+        }
+      },
+      "name": "Frame Content Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.5": {
+    "(0008,1140)": {
+      "items": {
+        "(0040,A170)": {
+          "cond": {
+            "type": "U"
+          },
+          "items": {
+            "include": [
+              "8.8-1"
+            ]
+          },
+          "name": "Purpose of Reference Code Sequence",
+          "type": "1C"
+        },
+        "include": [
+          "10-3"
+        ]
+      },
+      "name": "Referenced Image Sequence",
+      "type": "2"
+    }
+  },
+  "C.7.6.16.2.6": {
+    "(0008,9124)": {
+      "items": {
+        "(0008,2111)": {
+          "name": "Derivation Description",
+          "type": "3"
+        },
+        "(0008,2112)": {
+          "items": {
+            "(0020,0020)": {
+              "cond": {
+                "index": 0,
+                "op": "=",
+                "tag": "(0028,135A)",
+                "type": "MN",
+                "values": [
+                  "REORIENTED_ONLY"
+                ]
+              },
+              "name": "Patient Orientation",
+              "type": "1C"
+            },
+            "(0028,135A)": {
+              "name": "Spatial Locations Preserved",
+              "type": "3"
+            },
+            "(0040,A170)": {
+              "cond": {
+                "type": "U"
+              },
+              "items": {
+                "include": [
+                  "8.8-1"
+                ]
+              },
+              "name": "Purpose of Reference Code Sequence",
+              "type": "1C"
+            },
+            "include": [
+              "10-3"
+            ]
+          },
+          "name": "Source Image Sequence",
+          "type": "2"
+        },
+        "(0008,9215)": {
+          "cond": {
+            "type": "U"
+          },
+          "items": {
+            "include": [
+              "8.8-1"
+            ]
+          },
+          "name": "Derivation Code Sequence",
+          "type": "1C"
+        }
+      },
+      "name": "Derivation Image Sequence",
+      "type": "2"
+    }
+  },
+  "C.7.6.16.2.7": {
+    "(0018,9118)": {
+      "items": {
+        "(0018,1081)": {
+          "name": "Low R-R Value",
+          "type": "3"
+        },
+        "(0018,1082)": {
+          "name": "High R-R Value",
+          "type": "3"
+        },
+        "(0018,1083)": {
+          "name": "Intervals Acquired",
+          "type": "3"
+        },
+        "(0018,1084)": {
+          "name": "Intervals Rejected",
+          "type": "3"
+        },
+        "(0018,1088)": {
+          "name": "Heart Rate",
+          "type": "3"
+        },
+        "(0020,9153)": {
+          "name": "Nominal Cardiac Trigger Delay Time",
+          "type": "1"
+        },
+        "(0020,9154)": {
+          "name": "Nominal Cardiac Trigger Time Prior to R-peak",
+          "type": "3"
+        },
+        "(0020,9155)": {
+          "name": "Actual Cardiac Trigger Time Prior to R-peak",
+          "type": "3"
+        },
+        "(0020,9241)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Nominal Percentage of Cardiac Phase",
+          "type": "1C"
+        },
+        "(0020,9251)": {
+          "cond": {
+            "index": 0,
+            "op": "!=",
+            "tag": "(0018,9037)",
+            "type": "MU",
+            "values": [
+              "NONE",
+              "REALTIME"
+            ]
+          },
+          "name": "R-R Interval Time Nominal",
+          "type": "1C"
+        },
+        "(0020,9252)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1083)",
+            "type": "MU",
+            "values": [
+              "1"
+            ]
+          },
+          "name": "Actual Cardiac Trigger Delay Time",
+          "type": "1C"
+        }
+      },
+      "name": "Cardiac Synchronization Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.8": {
+    "(0020,9071)": {
+      "items": {
+        "(0020,9072)": {
+          "name": "Frame Laterality",
+          "type": "1"
+        },
+        "include": [
+          "10-5"
+        ]
+      },
+      "name": "Frame Anatomy Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.10": {
+    "(0028,9132)": {
+      "items": {
+        "(0028,1050)": {
+          "name": "Window Center",
+          "type": "1"
+        },
+        "(0028,1051)": {
+          "name": "Window Width",
+          "type": "1"
+        },
+        "(0028,1055)": {
+          "name": "Window Center & Width Explanation",
+          "type": "3"
+        },
+        "(0028,1056)": {
+          "name": "VOI LUT Function",
+          "type": "3"
+        }
+      },
+      "name": "Frame VOI LUT Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.12": {
+    "(0018,9341)": {
+      "items": {
+        "(0018,9337)": {
+          "name": "Contrast/Bolus Agent Number",
+          "type": "1"
+        },
+        "(0018,9342)": {
+          "name": "Contrast/Bolus Agent Administered",
+          "type": "1"
+        },
+        "(0018,9343)": {
+          "name": "Contrast/Bolus Agent Detected",
+          "type": "2"
+        },
+        "(0018,9344)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Contrast/Bolus Agent Phase",
+          "type": "2C"
+        }
+      },
+      "name": "Contrast/Bolus Usage Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.13": {
+    "(0028,9422)": {
+      "items": {
+        "(0028,3002)": {
+          "name": "LUT Descriptor",
+          "type": "1"
+        },
+        "(0028,3006)": {
+          "name": "LUT Data",
+          "type": "1"
+        },
+        "(0028,9474)": {
+          "name": "LUT Function",
+          "type": "1"
+        }
+      },
+      "name": "Pixel Intensity Relationship LUT Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.14": {
+    "(0028,9415)": {
+      "items": {
+        "(0028,6114)": {
+          "name": "Mask Sub-pixel Shift",
+          "type": "1"
+        },
+        "(0028,9416)": {
+          "name": "Subtraction Item ID",
+          "type": "1"
+        }
+      },
+      "name": "Frame Pixel Shift Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.15": {
+    "(0020,9450)": {
+      "items": {
+        "(0020,0020)": {
+          "name": "Patient Orientation",
+          "type": "1"
+        }
+      },
+      "name": "Patient Orientation in Frame Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.16": {
+    "(0018,9472)": {
+      "items": {
+        "include": [
+          "C.7-17a"
+        ]
+      },
+      "name": "Frame Display Shutter Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.17": {
+    "(0020,9253)": {
+      "items": {
+        "(0020,9245)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Nominal Percentage of Respiratory Phase",
+          "type": "1C"
+        },
+        "(0020,9246)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0020,9250)",
+            "type": "MN",
+            "values": [
+              "AMPLITUDE",
+              "BOTH"
+            ]
+          },
+          "name": "Starting Respiratory Amplitude",
+          "type": "1C"
+        },
+        "(0020,9247)": {
+          "cond": {
+            "index": 0,
+            "op": "+",
+            "tag": "(0020,9246)",
+            "type": "MN"
+          },
+          "name": "Starting Respiratory Phase",
+          "type": "1C"
+        },
+        "(0020,9248)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0020,9250)",
+            "type": "MN",
+            "values": [
+              "AMPLITUDE",
+              "BOTH"
+            ]
+          },
+          "name": "Ending Respiratory Amplitude",
+          "type": "1C"
+        },
+        "(0020,9249)": {
+          "cond": {
+            "index": 0,
+            "op": "+",
+            "tag": "(0020,9248)",
+            "type": "MN"
+          },
+          "name": "Ending Respiratory Phase",
+          "type": "1C"
+        },
+        "(0020,9254)": {
+          "cond": {
+            "and": [
+              {
+                "index": 0,
+                "op": "!=",
+                "tag": "(0018,9170)",
+                "values": [
+                  "NONE",
+                  "REALTIME"
+                ]
+              },
+              {
+                "index": 0,
+                "op": "-",
+                "tag": "(0020,9250)"
+              }
+            ],
+            "type": "MN"
+          },
+          "name": "Respiratory Interval Time",
+          "type": "1C"
+        },
+        "(0020,9255)": {
+          "name": "Nominal Respiratory Trigger Delay Time",
+          "type": "1"
+        },
+        "(0020,9257)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0020,9250)",
+            "type": "MN",
+            "values": [
+              "TIME",
+              "BOTH"
+            ]
+          },
+          "name": "Actual Respiratory Trigger Delay Time",
+          "type": "1C"
+        }
+      },
+      "name": "Respiratory Synchronization Sequence",
+      "type": "1"
+    }
+  },
+  "C.7.6.16.2.18": {
+    "(0018,9477)": {
+      "items": {
+        "(0008,3010)": {
+          "name": "Irradiation Event UID",
+          "type": "1"
+        }
+      },
+      "name": "Irradiation Event Identification Sequence",
+      "type": "1"
     }
   },
   "C.7.6.17": {
@@ -4502,6 +5034,111 @@
     "(0028,0009)": {
       "name": "Frame Increment Pointer",
       "type": "1"
+    }
+  },
+  "C.7-17a": {
+    "(0018,1600)": {
+      "name": "Shutter Shape",
+      "type": "1"
+    },
+    "(0018,1602)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "RECTANGULAR"
+        ]
+      },
+      "name": "Shutter Left Vertical Edge",
+      "type": "1C"
+    },
+    "(0018,1604)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "RECTANGULAR"
+        ]
+      },
+      "name": "Shutter Right Vertical Edge",
+      "type": "1C"
+    },
+    "(0018,1606)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "RECTANGULAR"
+        ]
+      },
+      "name": "Shutter Upper Horizontal Edge",
+      "type": "1C"
+    },
+    "(0018,1608)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "RECTANGULAR"
+        ]
+      },
+      "name": "Shutter Lower Horizontal Edge",
+      "type": "1C"
+    },
+    "(0018,1610)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "CIRCULAR"
+        ]
+      },
+      "name": "Center of Circular Shutter",
+      "type": "1C"
+    },
+    "(0018,1612)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "CIRCULAR"
+        ]
+      },
+      "name": "Radius of Circular Shutter",
+      "type": "1C"
+    },
+    "(0018,1620)": {
+      "cond": {
+        "index": 0,
+        "op": "=",
+        "tag": "(0018,1600)",
+        "type": "MN",
+        "values": [
+          "POLYGONAL"
+        ]
+      },
+      "name": "Vertices of the Polygonal Shutter",
+      "type": "1C"
+    },
+    "(0018,1622)": {
+      "name": "Shutter Presentation Value",
+      "type": "3"
+    },
+    "(0018,1624)": {
+      "name": "Shutter Presentation Color CIELab Value",
+      "type": "3"
     }
   },
   "C.8-131": {
@@ -5623,6 +6260,584 @@
         }
       },
       "name": "RT Dose ROI Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.1": {
+    "(0018,9412)": {
+      "items": {
+        "(0008,2111)": {
+          "name": "Derivation Description",
+          "type": "3"
+        },
+        "(0008,9215)": {
+          "items": {
+            "include": [
+              "8.8-1"
+            ]
+          },
+          "name": "Derivation Code Sequence",
+          "type": "3"
+        },
+        "(0018,1400)": {
+          "name": "Acquisition Device Processing Description",
+          "type": "3"
+        },
+        "(0018,1401)": {
+          "name": "Acquisition Device Processing Code",
+          "type": "3"
+        }
+      },
+      "name": "XA/XRF Frame Characteristics Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.2": {
+    "(0018,9432)": {
+      "items": {
+        "(0018,1147)": {
+          "name": "Field of View Shape",
+          "type": "3"
+        },
+        "(0018,7030)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9420)",
+            "type": "MU",
+            "values": [
+              "DIGITAL_DETECTOR"
+            ]
+          },
+          "name": "Field of View Origin",
+          "type": "1C"
+        },
+        "(0018,7032)": {
+          "name": "Field of View Rotation",
+          "type": "1"
+        },
+        "(0018,7034)": {
+          "name": "Field of View Horizontal Flip",
+          "type": "1"
+        },
+        "(0018,9433)": {
+          "name": "Field of View Description",
+          "type": "3"
+        },
+        "(0018,9461)": {
+          "name": "Field of View Dimension(s) in Float",
+          "type": "3"
+        }
+      },
+      "name": "Field of View Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.3": {
+    "(0018,9434)": {
+      "items": {
+        "(0018,9435)": {
+          "name": "Exposure Control Sensing Region Shape",
+          "type": "1"
+        },
+        "(0018,9436)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Exposure Control Sensing Region Left Vertical Edge",
+          "type": "1C"
+        },
+        "(0018,9437)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Exposure Control Sensing Region Right Vertical Edge",
+          "type": "1C"
+        },
+        "(0018,9438)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Exposure Control Sensing Region Upper Horizontal Edge",
+          "type": "1C"
+        },
+        "(0018,9439)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Exposure Control Sensing Region Lower Horizontal Edge",
+          "type": "1C"
+        },
+        "(0018,9440)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "CIRCULAR"
+            ]
+          },
+          "name": "Center of Circular Exposure Control Sensing Region",
+          "type": "1C"
+        },
+        "(0018,9441)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "CIRCULAR"
+            ]
+          },
+          "name": "Radius of Circular Exposure Control Sensing Region",
+          "type": "1C"
+        },
+        "(0018,9442)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,9435)",
+            "type": "MN",
+            "values": [
+              "POLYGONAL"
+            ]
+          },
+          "name": "Vertices of the Polygonal Exposure Control Sensing Region",
+          "type": "1C"
+        }
+      },
+      "name": "Exposure Control Sensing Regions Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.4": {
+    "(0028,9443)": {
+      "items": {
+        "(0008,9007)": {
+          "name": "Frame Type",
+          "type": "1"
+        },
+        "(0018,1164)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0008,0008)",
+            "type": "MU",
+            "values": [
+              "ORIGINAL"
+            ]
+          },
+          "name": "Imager Pixel Spacing",
+          "type": "1C"
+        },
+        "(0018,7036)": {
+          "name": "Pixel Data Area Origin Relative To FOV",
+          "type": "3"
+        },
+        "(0018,7038)": {
+          "name": "Pixel Data Area Rotation Angle Relative To FOV",
+          "type": "3"
+        },
+        "(0028,1040)": {
+          "name": "Pixel Intensity Relationship",
+          "type": "1"
+        },
+        "(0028,1041)": {
+          "name": "Pixel Intensity Relationship Sign",
+          "type": "1"
+        },
+        "(0028,9444)": {
+          "name": "Geometrical Properties",
+          "type": "1"
+        },
+        "(0028,9445)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0028,9444)",
+            "type": "MN",
+            "values": [
+              "NON_UNIFORM"
+            ]
+          },
+          "name": "Geometric Maximum Distortion",
+          "type": "2C"
+        },
+        "(0028,9446)": {
+          "name": "Image Processing Applied",
+          "type": "1"
+        }
+      },
+      "name": "Frame Pixel Data Properties Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.5": {
+    "(0018,9451)": {
+      "items": {
+        "(0018,7014)": {
+          "name": "Detector Active Time",
+          "type": "3"
+        },
+        "(0018,7016)": {
+          "name": "Detector Activation Offset From Exposure",
+          "type": "3"
+        }
+      },
+      "name": "Frame Detector Parameters Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.6": {
+    "(0018,9455)": {
+      "items": {
+        "(0050,0004)": {
+          "name": "Calibration Image",
+          "type": "1"
+        }
+      },
+      "name": "Calibration Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.7": {
+    "(0018,9456)": {
+      "items": {
+        "(0018,9452)": {
+          "name": "Calculated Anatomy Thickness",
+          "type": "1"
+        }
+      },
+      "name": "Object Thickness Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.8": {
+    "(0018,9417)": {
+      "items": {
+        "(0018,0060)": {
+          "name": "KVP",
+          "type": "1"
+        },
+        "(0018,9330)": {
+          "name": "X-Ray Tube Current in mA",
+          "type": "1"
+        }
+      },
+      "name": "Frame Acquisition Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.9": {
+    "(0018,9401)": {
+      "items": {
+        "(0018,1130)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0008,0008)",
+            "type": "MU",
+            "values": [
+              "ORIGINAL"
+            ]
+          },
+          "name": "Table Height",
+          "type": "1C"
+        },
+        "(0018,9403)": {
+          "name": "Distance Object to Table Top",
+          "type": "2"
+        },
+        "(0018,9404)": {
+          "cond": {
+            "type": "U"
+          },
+          "name": "Object Pixel Spacing in Center of Beam",
+          "type": "1C"
+        },
+        "(0018,9449)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0008,0008)",
+            "type": "MU",
+            "values": [
+              "ORIGINAL"
+            ]
+          },
+          "name": "Beam Angle",
+          "type": "1C"
+        }
+      },
+      "name": "Projection Pixel Calibration Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.10": {
+    "(0018,9405)": {
+      "items": {
+        "(0018,1510)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1508)",
+            "type": "MN",
+            "values": [
+              "CARM"
+            ]
+          },
+          "name": "Positioner Primary Angle",
+          "type": "1C"
+        },
+        "(0018,1511)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1508)",
+            "type": "MN",
+            "values": [
+              "CARM"
+            ]
+          },
+          "name": "Positioner Secondary Angle",
+          "type": "1C"
+        },
+        "(0018,9447)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1508)",
+            "type": "MN",
+            "values": [
+              "COLUMN"
+            ]
+          },
+          "name": "Column Angulation (Patient)",
+          "type": "1C"
+        }
+      },
+      "name": "Positioner Position Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.11": {
+    "(0018,9406)": {
+      "items": {
+        "(0018,9469)": {
+          "name": "Table Horizontal Rotation Angle",
+          "type": "1"
+        },
+        "(0018,9470)": {
+          "name": "Table Head Tilt Angle",
+          "type": "1"
+        },
+        "(0018,9471)": {
+          "name": "Table Cradle Tilt Angle",
+          "type": "1"
+        },
+        "(300A,0128)": {
+          "name": "Table Top Vertical Position",
+          "type": "1"
+        },
+        "(300A,0129)": {
+          "name": "Table Top Longitudinal Position",
+          "type": "1"
+        },
+        "(300A,012A)": {
+          "name": "Table Top Lateral Position",
+          "type": "1"
+        }
+      },
+      "name": "Table Position Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.12": {
+    "(0018,9407)": {
+      "items": {
+        "(0018,1700)": {
+          "name": "Collimator Shape",
+          "type": "1"
+        },
+        "(0018,1702)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Collimator Left Vertical Edge",
+          "type": "1C"
+        },
+        "(0018,1704)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Collimator Right Vertical Edge",
+          "type": "1C"
+        },
+        "(0018,1706)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Collimator Upper Horizontal Edge",
+          "type": "1C"
+        },
+        "(0018,1708)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "RECTANGULAR"
+            ]
+          },
+          "name": "Collimator Lower Horizontal Edge",
+          "type": "1C"
+        },
+        "(0018,1710)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "CIRCULAR"
+            ]
+          },
+          "name": "Center of Circular Collimator",
+          "type": "1C"
+        },
+        "(0018,1712)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "CIRCULAR"
+            ]
+          },
+          "name": "Radius of Circular Collimator",
+          "type": "1C"
+        },
+        "(0018,1720)": {
+          "cond": {
+            "index": 0,
+            "op": "=",
+            "tag": "(0018,1700)",
+            "type": "MN",
+            "values": [
+              "POLYGONAL"
+            ]
+          },
+          "name": "Vertices of the Polygonal Collimator",
+          "type": "1C"
+        }
+      },
+      "name": "Collimator Shape Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.13": {
+    "(0018,9462)": {
+      "items": {
+        "(0018,9463)": {
+          "name": "Positioner Isocenter Primary Angle",
+          "type": "1"
+        },
+        "(0018,9464)": {
+          "name": "Positioner Isocenter Secondary Angle",
+          "type": "1"
+        },
+        "(0018,9465)": {
+          "name": "Positioner Isocenter Detector Rotation Angle",
+          "type": "1"
+        },
+        "(0018,9466)": {
+          "name": "Table X Position to Isocenter",
+          "type": "1"
+        },
+        "(0018,9467)": {
+          "name": "Table Y Position to Isocenter",
+          "type": "1"
+        },
+        "(0018,9468)": {
+          "name": "Table Z Position to Isocenter",
+          "type": "1"
+        },
+        "(0018,9469)": {
+          "name": "Table Horizontal Rotation Angle",
+          "type": "1"
+        },
+        "(0018,9470)": {
+          "name": "Table Head Tilt Angle",
+          "type": "1"
+        },
+        "(0018,9471)": {
+          "name": "Table Cradle Tilt Angle",
+          "type": "1"
+        }
+      },
+      "name": "Isocenter Reference System Sequence",
+      "type": "1"
+    }
+  },
+  "C.8.19.6.14": {
+    "(0018,9476)": {
+      "items": {
+        "(0018,1110)": {
+          "name": "Distance Source to Detector",
+          "type": "1"
+        },
+        "(0018,9402)": {
+          "name": "Distance Source to Isocenter",
+          "type": "1"
+        }
+      },
+      "name": "X-Ray Geometry Sequence",
       "type": "1"
     }
   },

--- a/dicom_validator/tests/spec_reader/test_part6_reader.py
+++ b/dicom_validator/tests/spec_reader/test_part6_reader.py
@@ -1,49 +1,30 @@
-from pathlib import Path
-
 import pytest
-
-from dicom_validator.spec_reader.part6_reader import Part6Reader
-
-
-@pytest.fixture(scope="module")
-def doc_contents(spec_fixture_path):
-    with open(spec_fixture_path / "part06.xml", "rb") as spec_file:
-        contents = spec_file.read()
-    yield contents
-
-
-@pytest.fixture
-def reader(fs, doc_contents):
-    spec_path = Path("dicom", "docbook")
-    part6_path = spec_path / "part06.xml"
-    fs.create_file(part6_path, contents=doc_contents)
-    yield Part6Reader(spec_path)
 
 
 @pytest.mark.usefixtures("fs")
 class TestPart6Reader:
-    def test_undefined_id(self, reader):
-        assert reader.data_element("(0011,0011)") is None
+    def test_undefined_id(self, dict_reader):
+        assert dict_reader.data_element("(0011,0011)") is None
 
-    def test_data_element(self, reader):
-        element = reader.data_element("(0008,0005)")
+    def test_data_element(self, dict_reader):
+        element = dict_reader.data_element("(0008,0005)")
         assert element is not None
         assert element["name"] == "Specific Character Set"
         assert element["vr"] == "CS"
         assert element["vm"] == "1-n"
 
-    def test_data_elements(self, reader):
-        elements = reader.data_elements()
+    def test_data_elements(self, dict_reader):
+        elements = dict_reader.data_elements()
         assert len(elements) == 8
 
-    def test_sop_class_uids(self, reader):
-        sop_class_uids = reader.sop_class_uids()
+    def test_sop_class_uids(self, dict_reader):
+        sop_class_uids = dict_reader.sop_class_uids()
         assert len(sop_class_uids) == 3
         assert "1.2.840.10008.1.1" in sop_class_uids
         assert sop_class_uids["1.2.840.10008.1.1"] == "Verification SOP Class"
 
-    def test_uid_type(self, reader):
-        xfer_syntax_uids = reader.uids("Transfer Syntax")
+    def test_uid_type(self, dict_reader):
+        xfer_syntax_uids = dict_reader.uids("Transfer Syntax")
         assert len(xfer_syntax_uids) == 2
         assert "1.2.840.10008.1.2.4.80" in xfer_syntax_uids
         assert (
@@ -51,19 +32,21 @@ class TestPart6Reader:
             == "JPEG-LS Lossless Image Compression"
         )
 
-    def test_all_uids(self, reader):
-        uids = reader.all_uids()
+    def test_all_uids(self, dict_reader):
+        uids = dict_reader.all_uids()
         assert len(uids) == 2
         assert "Transfer Syntax" in uids
         assert "SOP Class" in uids
         uid_nr = sum([len(uid_dict) for uid_dict in uids.values()])
         assert uid_nr == 5
 
-    def test_sop_class_name(self, reader):
+    def test_sop_class_name(self, dict_reader):
         assert (
-            reader.sop_class_name("1.2.840.10008.5.1.4.1.1.6.2")
+            dict_reader.sop_class_name("1.2.840.10008.5.1.4.1.1.6.2")
             == "Enhanced US Volume Storage"
         )
 
-    def test_sop_class_uid(self, reader):
-        assert reader.sop_class_uid("CT Image Storage") == "1.2.840.10008.5.1.4.1.1.2"
+    def test_sop_class_uid(self, dict_reader):
+        assert (
+            dict_reader.sop_class_uid("CT Image Storage") == "1.2.840.10008.5.1.4.1.1.2"
+        )

--- a/dicom_validator/tests/utils.py
+++ b/dicom_validator/tests/utils.py
@@ -1,0 +1,7 @@
+def has_tag_error(messages, module_name, tag_id_string, error_kind):
+    if module_name not in messages:
+        return False
+    for message in messages[module_name]:
+        if message.startswith(f"Tag {tag_id_string} is {error_kind}"):
+            return True
+    return False

--- a/dicom_validator/tests/validator/test_iod_validator_func_groups.py
+++ b/dicom_validator/tests/validator/test_iod_validator_func_groups.py
@@ -1,0 +1,140 @@
+import logging
+
+import pytest
+from pydicom import Sequence
+from pydicom.dataset import Dataset
+
+from dicom_validator.tests.utils import has_tag_error
+from dicom_validator.validator.iod_validator import IODValidator
+
+pytestmark = pytest.mark.usefixtures("disable_logging")
+
+
+def new_data_set(shared_macros, per_frame_macros):
+    """Create a DICOM data set with the given attributes"""
+    data_set = Dataset()
+    # Enhanced X-Ray Angiographic Image
+    data_set.SOPClassUID = "1.2.840.10008.5.1.4.1.1.12.1.1"
+    data_set.PatientName = "XXX"
+    data_set.PatientID = "ZZZ"
+    data_set.ImageType = "DERIVED"
+    data_set.InstanceNumber = "1"
+    data_set.ContentDate = "20000101"
+    data_set.ContentTime = "120000"
+    data_set.NumberOfFrames = "3"
+    shared_groups = Sequence()
+    if shared_macros:
+        item = Dataset()
+        for macro in shared_macros:
+            add_contents_to_item(item, macro)
+        shared_groups.append(item)
+    data_set.SharedFunctionalGroupsSequence = shared_groups
+
+    per_frame_groups = Sequence()
+    if per_frame_macros:
+        for i in range(3):
+            # we don't care about the tag contents, we just put the same values
+            # into each per-frame item
+            item = Dataset()
+            for macro in per_frame_macros:
+                add_contents_to_item(item, macro)
+            per_frame_groups.append(item)
+    data_set.PerFrameFunctionalGroupsSequence = per_frame_groups
+
+    data_set.file_meta = Dataset()
+    data_set.is_implicit_VR = False
+    data_set.is_little_endian = True
+    return data_set
+
+
+def add_contents_to_item(item, contents):
+    for name, content in contents.items():
+        if isinstance(content, list):
+            value = Sequence()
+            add_items_to_sequence(value, content)
+        else:
+            value = content
+        setattr(item, name, value)
+
+
+def add_items_to_sequence(sequence, contents):
+    for content in contents:
+        item = Dataset()
+        add_contents_to_item(item, content)
+        sequence.append(item)
+
+
+@pytest.fixture
+def validator(iod_info, module_info, request):
+    marker = request.node.get_closest_marker("shared_macros")
+    shared_macros = {} if marker is None else marker.args[0]
+    marker = request.node.get_closest_marker("per_frame_macros")
+    per_frame_macros = {} if marker is None else marker.args[0]
+    data_set = new_data_set(shared_macros, per_frame_macros)
+    return IODValidator(data_set, iod_info, module_info, None, logging.ERROR)
+
+
+FRAME_ANATOMY = {
+    "FrameAnatomySequence": [
+        {
+            "FrameLaterality": "R",
+            "AnatomicRegionSequence": [
+                {
+                    "CodeValue": "T-D3000",
+                    "CodingSchemeDesignator": "SRT",
+                    "CodingSchemeVersion": "1",
+                    "CodeMeaning": "Chest",
+                }
+            ],
+        }
+    ]
+}
+
+FRAME_VOI_LUT = {
+    "FrameVOILUTSequence": [{"WindowCenter": "7200", "WindowWidth": "12800"}]
+}
+
+
+class TestIODValidatorFuncGroups:
+    """Tests IODValidator for functional groups."""
+
+    def ensure_group_result(self, result):
+        assert "Multi-frame Functional Groups" in result
+        return result["Multi-frame Functional Groups"]
+
+    def test_missing_func_groups(self, iod_info, module_info):
+        data_set = new_data_set({}, {})
+        del data_set[0x52009229]
+        del data_set[0x52009230]
+        validator = IODValidator(data_set, iod_info, module_info, None, logging.ERROR)
+        result = validator.validate()
+        group_result = self.ensure_group_result(result)
+        assert "Tag (5200,9229) is missing" in group_result
+        assert "Tag (5200,9230) is missing" in group_result
+
+    def test_empty_func_groups(self, validator):
+        result = validator.validate()
+        group_result = self.ensure_group_result(result).keys()
+        assert "Tag (5200,9229) is empty" in group_result
+        assert "Tag (5200,9230) is empty" in group_result
+
+    @pytest.mark.shared_macros([FRAME_ANATOMY])
+    @pytest.mark.per_frame_macros([FRAME_VOI_LUT])
+    def test_missing_sequences(self, validator):
+        result = validator.validate()
+        # Frame Content Sequence (mandatory, missing)
+        assert has_tag_error(result, "Frame Content", "(0020,9111)", "missing")
+        # Frame Anatomy Sequence (present in shared groups)
+        assert not has_tag_error(result, "Frame Anatomy", "(0020,9071)", "missing")
+        # Frame VOI LUT Sequence (present in per-frame groups)
+        assert not has_tag_error(result, "Frame VOI LUT", "(0028,9132)", "missing")
+        # Referenced Image Sequence (not mandatory)
+        assert not has_tag_error(result, "Referenced Image", "(0008,1140)", "missing")
+
+    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.shared_macros([FRAME_ANATOMY])
+    @pytest.mark.per_frame_macros([FRAME_ANATOMY])
+    def test_sequence_in_shared_and_per_frame(self, validator):
+        result = validator.validate()
+        # Frame Anatomy Sequence (present in shared groups)
+        assert has_tag_error(result, "Frame Anatomy", "(0020,9071)", "not allowed")


### PR DESCRIPTION
- add functional group macro info to iod info
- add special handling for functional groups
- still missing: handle macros that are not allowed in either shared or per-frame groups handle duplicate tags in both groups

This is ongoing work, but I'll probably merge an initial version first, and handle other problems first before going back to this.