### PR TITLE
Validate values against value representations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,16 @@
 # Dicom Validator Release Notes
 The released versions correspond to PyPi releases.
 
-## [Version 0.5.1](https://pypi.python.org/pypi/dicom-validator/0.5.0) (2024-04-06)
+## [Version TBD](https://pypi.python.org/pypi/dicom-validator/TBD) (TBD)
+
+### Features
+* iod_validator: added validation of values against value representations, with
+  a new option `-svr` to suppress the above check
+
+### Fixes
+* ???
+
+## [Version 0.5.1](https://pypi.python.org/pypi/dicom-validator/0.5.1) (2024-04-06)
 Fixes for enum checks.
 
 ### Features

--- a/dicom_validator/tests/validator/test_dicom_file_validator.py
+++ b/dicom_validator/tests/validator/test_dicom_file_validator.py
@@ -56,15 +56,14 @@ class TestFakeDicomFileValidator:
 
     def test_unknown_sop_class(self, validator):
         dataset = Dataset()
-        with pytest.warns(UserWarning, match="Invalid value for VR UI*"):
-            dataset.SOPClassUID = "Unknown"
-            file_dataset = FileDataset(
-                "test", dataset, file_meta=self.create_metadata()
-            )
-            write_file("test", file_dataset, write_like_original=False)
-            self.assert_fatal_error(
-                validator, "test", "Unknown SOPClassUID (probably retired): Unknown"
-            )
+        dataset.SOPClassUID = "Unknown"
+        file_dataset = FileDataset(
+            "test", dataset, file_meta=self.create_metadata()
+        )
+        write_file("test", file_dataset, write_like_original=False)
+        self.assert_fatal_error(
+            validator, "test", "Unknown SOPClassUID (probably retired): Unknown"
+        )
 
     def test_validate_dir(self, fs, validator):
         fs.create_dir(os.path.join("foo", "bar", "baz"))

--- a/dicom_validator/tests/validator/test_dicom_file_validator.py
+++ b/dicom_validator/tests/validator/test_dicom_file_validator.py
@@ -57,9 +57,7 @@ class TestFakeDicomFileValidator:
     def test_unknown_sop_class(self, validator):
         dataset = Dataset()
         dataset.SOPClassUID = "Unknown"
-        file_dataset = FileDataset(
-            "test", dataset, file_meta=self.create_metadata()
-        )
+        file_dataset = FileDataset("test", dataset, file_meta=self.create_metadata())
         write_file("test", file_dataset, write_like_original=False)
         self.assert_fatal_error(
             validator, "test", "Unknown SOPClassUID (probably retired): Unknown"

--- a/dicom_validator/tests/validator/test_iod_validator.py
+++ b/dicom_validator/tests/validator/test_iod_validator.py
@@ -91,6 +91,20 @@ class TestIODValidator:
 
     @pytest.mark.tag_set(
         {
+            "SOPClassUID": "1.2.840.10008.5.1.4.1.1.2",  # CT
+            "TypeOfPatientID": "lowercase",  # VR is CS, which is required to be uppercase
+            "Modality": None,
+        }
+    )
+    def test_vr_conflict(self, validator):
+        result = validator.validate()
+
+        assert "fatal" not in result
+        assert "CT Image" in result
+        assert has_tag_error(result, "Patient", "(0010,0022)", "conflicting")
+
+    @pytest.mark.tag_set(
+        {
             # Enhanced X-Ray Angiographic Image
             "SOPClassUID": "1.2.840.10008.5.1.4.1.1.12.1.1",
             "CArmPositionerTabletopRelationship": "YES",

--- a/dicom_validator/validate_iods.py
+++ b/dicom_validator/validate_iods.py
@@ -10,7 +10,7 @@ def validate(args, base_path):
     json_path = Path(base_path, "json")
     dicom_info = EditionReader.load_dicom_info(json_path)
     log_level = logging.DEBUG if args.verbose else logging.INFO
-    validator = DicomFileValidator(dicom_info, log_level, args.force_read)
+    validator = DicomFileValidator(dicom_info, log_level, args.force_read, args.suppress_vr_warnings)
     error_nr = 0
     for dicom_path in args.dicomfiles:
         error_nr += sum(
@@ -50,6 +50,13 @@ def main(args=None):
         "--recreate-json",
         action="store_true",
         help="Force recreating the JSON information from the DICOM specs",
+        default=False,
+    )
+    parser.add_argument(
+        "--suppress-vr-warnings",
+        "-svr",
+        action="store_true",
+        help="Suppress warnings for values not matching value representation (VR)",
         default=False,
     )
     parser.add_argument(

--- a/dicom_validator/validate_iods.py
+++ b/dicom_validator/validate_iods.py
@@ -10,7 +10,9 @@ def validate(args, base_path):
     json_path = Path(base_path, "json")
     dicom_info = EditionReader.load_dicom_info(json_path)
     log_level = logging.DEBUG if args.verbose else logging.INFO
-    validator = DicomFileValidator(dicom_info, log_level, args.force_read, args.suppress_vr_warnings)
+    validator = DicomFileValidator(
+        dicom_info, log_level, args.force_read, args.suppress_vr_warnings
+    )
     error_nr = 0
     for dicom_path in args.dicomfiles:
         error_nr += sum(

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -45,7 +45,7 @@ class DicomFileValidator:
 
     def validate_file(self, file_path):
         self.logger.info('\nProcessing DICOM file "%s"', file_path)
-        try:            
+        try:
             # dcmread calls validate_value by default. If values don't match
             # required VR (value representation), it emits a warning but
             # not provide the tag and value that caused the warning.
@@ -65,6 +65,3 @@ class DicomFileValidator:
                 suppress_vr_warnings=self._suppress_vr_warnings,
             ).validate()
         }
-
-
-                    

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -1,9 +1,6 @@
-from dataclasses import dataclass
 import logging
 import os
 import sys
-from typing import Any
-import warnings
 
 from pydicom import config, dcmread
 from pydicom.errors import InvalidDicomError

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -6,7 +6,6 @@ from typing import Any
 import warnings
 
 from pydicom import config, dcmread
-from pydicom.valuerep import validate_value
 from pydicom.errors import InvalidDicomError
 
 from dicom_validator.validator.iod_validator import IODValidator
@@ -50,14 +49,13 @@ class DicomFileValidator:
     def validate_file(self, file_path):
         self.logger.info('\nProcessing DICOM file "%s"', file_path)
         try:            
-            # Suppress warnings about invalid values while reading the file.
-            # The default behavior emits a warning, but unfortunately it does
-            # not provide the tag and value that caused the warning. We will
-            # handle it ourselves after reading the file.
+            # dcmread calls validate_value by default. If values don't match
+            # required VR (value representation), it emits a warning but
+            # not provide the tag and value that caused the warning.
+            # We will handle it later (optionally) by calling validate_value
+            # directly.
             config.settings.reading_validation_mode = config.IGNORE
             data_set = dcmread(file_path, defer_size=1024, force=self._force_read)
-            if not self._suppress_vr_warnings:
-                self.validate_dicom_values(data_set)
 
         except InvalidDicomError:
             self.logger.error(f"Invalid DICOM file: {file_path}")
@@ -67,47 +65,9 @@ class DicomFileValidator:
                 data_set,
                 self._dicom_info,
                 self.logger.level,
+                suppress_vr_warnings=self._suppress_vr_warnings,
             ).validate()
         }
 
-    def validate_dicom_values(self, data_set) -> None:
-        # Confirm that SOPClassUID is valid. Skip the check if SopClassUID
-        # is present, since validator will result in a fatal error if it is missing.
-        if "SOPClassUID" in data_set:
-            validate_value("UI", data_set.SOPClassUID, config.WARN)
 
-        @dataclass
-        class TagValue:
-            tag: str
-            VR: str
-            value: Any
-
-        invalid_values = []
-
-        for tt in data_set:
-            if tt.value is None:
-                continue
-            values = [tt.value] if tt.VM == 1 else list(tt.value)
-            for vv in values:
-                # Convert the value to a string if it is a number to avoid
-                # raising an exception when validating the value.
-                # TODO: What is the right way to do this? Should we update the
-                # validator in pydicom's valuerep.py instead of hacking it here?
-                if tt.VR in ["IS", "DS"]:
-                    vv = str(vv)
-                try:
-                    validate_value(tt.VR, vv, config.RAISE)
-                except Exception as _:
-                    invalid_values.append(
-                        TagValue(tag=str(tt.tag).replace(' ', ''),
-                                 VR=tt.VR,
-                                 value=vv)
-                                 )
-
-        if invalid_values:
-            self.logger.warning("\nWarnings for values not matching value representation (VR).\n"
-                                "========")
-            for iv in invalid_values:
-                self.logger.warning("Tag %s: invalid value (%s) for VR %s", iv.tag, iv.value, iv.VR)
-            self.logger.warning("See https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html#table_6.2-1\n")
                     

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -1,8 +1,12 @@
+from dataclasses import dataclass
 import logging
 import os
 import sys
+from typing import Any
+import warnings
 
-from pydicom import dcmread
+from pydicom import config, dcmread
+from pydicom.valuerep import validate_value
 from pydicom.errors import InvalidDicomError
 
 from dicom_validator.validator.iod_validator import IODValidator
@@ -14,6 +18,7 @@ class DicomFileValidator:
         dicom_info,
         log_level=logging.INFO,
         force_read=False,
+        suppress_vr_warnings=False,
     ):
         self._dicom_info = dicom_info
         self.logger = logging.getLogger()
@@ -21,6 +26,7 @@ class DicomFileValidator:
         if not self.logger.hasHandlers():
             self.logger.addHandler(logging.StreamHandler(sys.stdout))
         self._force_read = force_read
+        self._suppress_vr_warnings = suppress_vr_warnings
 
     def validate(self, path):
         errors = {}
@@ -43,8 +49,16 @@ class DicomFileValidator:
 
     def validate_file(self, file_path):
         self.logger.info('\nProcessing DICOM file "%s"', file_path)
-        try:
+        try:            
+            # Suppress warnings about invalid values while reading the file.
+            # The default behavior emits a warning, but unfortunately it does
+            # not provide the tag and value that caused the warning. We will
+            # handle it ourselves after reading the file.
+            config.settings.reading_validation_mode = config.IGNORE
             data_set = dcmread(file_path, defer_size=1024, force=self._force_read)
+            if not self._suppress_vr_warnings:
+                self.validate_dicom_values(data_set)
+
         except InvalidDicomError:
             self.logger.error(f"Invalid DICOM file: {file_path}")
             return {file_path: {"fatal": "Invalid DICOM file"}}
@@ -55,3 +69,45 @@ class DicomFileValidator:
                 self.logger.level,
             ).validate()
         }
+
+    def validate_dicom_values(self, data_set) -> None:
+        # Confirm that SOPClassUID is valid. Skip the check if SopClassUID
+        # is present, since validator will result in a fatal error if it is missing.
+        if "SOPClassUID" in data_set:
+            validate_value("UI", data_set.SOPClassUID, config.WARN)
+
+        @dataclass
+        class TagValue:
+            tag: str
+            VR: str
+            value: Any
+
+        invalid_values = []
+
+        for tt in data_set:
+            if tt.value is None:
+                continue
+            values = [tt.value] if tt.VM == 1 else list(tt.value)
+            for vv in values:
+                # Convert the value to a string if it is a number to avoid
+                # raising an exception when validating the value.
+                # TODO: What is the right way to do this? Should we update the
+                # validator in pydicom's valuerep.py instead of hacking it here?
+                if tt.VR in ["IS", "DS"]:
+                    vv = str(vv)
+                try:
+                    validate_value(tt.VR, vv, config.RAISE)
+                except Exception as _:
+                    invalid_values.append(
+                        TagValue(tag=str(tt.tag).replace(' ', ''),
+                                 VR=tt.VR,
+                                 value=vv)
+                                 )
+
+        if invalid_values:
+            self.logger.warning("\nWarnings for values not matching value representation (VR).\n"
+                                "========")
+            for iv in invalid_values:
+                self.logger.warning("Tag %s: invalid value (%s) for VR %s", iv.tag, iv.value, iv.VR)
+            self.logger.warning("See https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html#table_6.2-1\n")
+                    

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -107,7 +107,9 @@ class InvalidParameterError(Exception):
 
 
 class IODValidator:
-    def __init__(self, dataset, dicom_info, log_level=logging.INFO, suppress_vr_warnings=False):
+    def __init__(
+        self, dataset, dicom_info, log_level=logging.INFO, suppress_vr_warnings=False
+    ):
         self._dataset = dataset
         self._dataset_stack = [DatasetStackItem(self._dataset, None)]
         self._dicom_info = dicom_info

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -3,8 +3,9 @@ import logging
 import sys
 from dataclasses import dataclass
 
-from pydicom import Sequence
+from pydicom import config, Sequence
 from pydicom.multival import MultiValue
+from pydicom.valuerep import validate_value
 from pydicom.tag import Tag
 
 from dicom_validator.spec_reader.condition import (
@@ -106,11 +107,12 @@ class InvalidParameterError(Exception):
 
 
 class IODValidator:
-    def __init__(self, dataset, dicom_info, log_level=logging.INFO):
+    def __init__(self, dataset, dicom_info, log_level=logging.INFO, suppress_vr_warnings=False):
         self._dataset = dataset
         self._dataset_stack = [DatasetStackItem(self._dataset, None)]
         self._dicom_info = dicom_info
         self._func_group_info = FunctionalGroupInfo({}, set())
+        self._suppress_vr_warnings = suppress_vr_warnings
         self.errors = {}
         self.logger = logging.getLogger("validator")
         self.logger.level = log_level
@@ -386,26 +388,36 @@ class IODValidator:
             error_kind = "missing"
         elif has_tag and not tag_allowed:
             error_kind = "not allowed"
-        elif has_tag and (value_required or "enums" in attribute):
+        elif has_tag: #and (value_required or "enums" in attribute):
             value = self._dataset_stack[-1].dataset[tag_id].value
+            vr = self._dataset_stack[-1].dataset[tag_id].VR
             if value_required:
                 if value is None or isinstance(value, Sequence) and not value:
                     error_kind = "empty"
-            if value is not None and "enums" in attribute:
+            if value is not None:
                 if not isinstance(value, MultiValue):
                     value = [value]
                 for i, v in enumerate(value):
-                    for enums in attribute["enums"]:
-                        # if an index is there, we only check the value for the
-                        # correct index; otherwise there will only be one entry
-                        if "index" in enums and int(enums["index"]) != i + 1:
-                            continue
-                        if v not in enums["val"]:
-                            error_kind = "value is not allowed"
-                            extra_msg = (
-                                f" (value: {v}, allowed: "
-                                f"{', '.join([str(e) for e in enums['val']])})"
-                            )
+                    if "enums" in attribute:
+                        for enums in attribute["enums"]:
+                            # if an index is there, we only check the value for the
+                            # correct index; otherwise there will only be one entry
+                            if "index" in enums and int(enums["index"]) != i + 1:
+                                continue
+                            if v not in enums["val"]:
+                                error_kind = "value is not allowed"
+                                extra_msg = (
+                                    f" (value: {v}, allowed: "
+                                    f"{', '.join([str(e) for e in enums['val']])})"
+                                )
+                    if not self._suppress_vr_warnings and error_kind is None:
+                        if True: #not self._suppress_vr_warnings:
+                            vv = str(v) if vr in ("DS", "IS") else v
+                            try:
+                                validate_value(vr, vv, config.RAISE)
+                            except Exception as _:
+                                error_kind = "conflicting with VR"
+                                extra_msg = f" (value: {vv}, VR: {vr})"
 
         if error_kind is not None:
             extra_msg = extra_msg or self._condition_message(condition_dict)

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -388,7 +388,7 @@ class IODValidator:
             error_kind = "missing"
         elif has_tag and not tag_allowed:
             error_kind = "not allowed"
-        elif has_tag: #and (value_required or "enums" in attribute):
+        elif has_tag:
             value = self._dataset_stack[-1].dataset[tag_id].value
             vr = self._dataset_stack[-1].dataset[tag_id].VR
             if value_required:
@@ -411,13 +411,12 @@ class IODValidator:
                                     f"{', '.join([str(e) for e in enums['val']])})"
                                 )
                     if not self._suppress_vr_warnings and error_kind is None:
-                        if True: #not self._suppress_vr_warnings:
-                            vv = str(v) if vr in ("DS", "IS") else v
-                            try:
-                                validate_value(vr, vv, config.RAISE)
-                            except Exception as _:
-                                error_kind = "conflicting with VR"
-                                extra_msg = f" (value: {vv}, VR: {vr})"
+                        vv = str(v) if vr in ("DS", "IS") else v
+                        try:
+                            validate_value(vr, vv, config.RAISE)
+                        except Exception as _:
+                            error_kind = "conflicting with VR"
+                            extra_msg = f" (value: {vv}, VR: {vr})"
 
         if error_kind is not None:
             extra_msg = extra_msg or self._condition_message(condition_dict)


### PR DESCRIPTION
Fix for #102

- Added check for value representation by calling pydicom's `validate_value` directly
- Suppressed warnings about invalid values while reading DICOM file
- Added option to suppress this new check
- Updated unit test, since user warning is no longer issued for invalid SOPClassUID. A fatal error is raised correctly.