### PR TITLE
Suppress warnings from dump_dcm_info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,14 @@
 # Dicom Validator Release Notes
 The released versions correspond to PyPi releases.
 
-## [Version TBD](https://pypi.python.org/pypi/dicom-validator/TBD) (TBD)
+## [Version 0.6.0](https://pypi.python.org/pypi/dicom-validator/0.6.0) (0.6.0)
 
 ### Features
 * iod_validator: added validation of values against value representations, with
   a new option `-svr` to suppress the above check
 
 ### Fixes
-* ???
+* * dump_dcm_info: suppressed invalid value warnings from dicomread
 
 ## [Version 0.5.1](https://pypi.python.org/pypi/dicom-validator/0.5.1) (2024-04-06)
 Fixes for enum checks.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ The released versions correspond to PyPi releases.
   a new option `-svr` to suppress the above check
 
 ### Fixes
-* * dump_dcm_info: suppressed invalid value warnings from dicomread
+* dump_dcm_info: suppressed invalid value warnings from dicomread
 
 ## [Version 0.5.1](https://pypi.python.org/pypi/dicom-validator/0.5.1) (2024-04-06)
 Fixes for enum checks.

--- a/dicom_validator/dump_dcm_info.py
+++ b/dicom_validator/dump_dcm_info.py
@@ -6,8 +6,9 @@ import argparse
 import os
 import re
 from pathlib import Path
+import sys
 
-from pydicom import dcmread
+from pydicom import config, dcmread
 from pydicom.errors import InvalidDicomError
 
 from dicom_validator.spec_reader.edition_reader import EditionReader
@@ -111,6 +112,12 @@ class DataElementDumper:
 
     def dump_file(self, file_path):
         try:
+            # dcmread calls validate_value by default. If values don't match
+            # required VR (value representation), it emits a warning but
+            # not provide the tag and value that caused the warning.
+            # There is no point in warning the user when dumping the tags.
+            # The validate_iods.py script handles these separately.
+            config.settings.reading_validation_mode = config.IGNORE
             print("\n" + file_path)
             dataset = dcmread(
                 file_path, stop_before_pixels=self.show_image_data, force=True
@@ -199,4 +206,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/dicom_validator/dump_dcm_info.py
+++ b/dicom_validator/dump_dcm_info.py
@@ -114,7 +114,7 @@ class DataElementDumper:
         try:
             # dcmread calls validate_value by default. If values don't match
             # required VR (value representation), it emits a warning but
-            # not provide the tag and value that caused the warning.
+            # does not provide the tag and value that caused the warning.
             # There is no point in warning the user when dumping the tags.
             # The validate_iods.py script handles these separately.
             config.settings.reading_validation_mode = config.IGNORE

--- a/dicom_validator/validate_iods.py
+++ b/dicom_validator/validate_iods.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 from pathlib import Path
+import sys
 
 from dicom_validator.spec_reader.edition_reader import EditionReader
 from dicom_validator.validator.dicom_file_validator import DicomFileValidator
@@ -76,4 +77,4 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/dicom_validator/validator/dicom_file_validator.py
+++ b/dicom_validator/validator/dicom_file_validator.py
@@ -48,7 +48,7 @@ class DicomFileValidator:
         try:
             # dcmread calls validate_value by default. If values don't match
             # required VR (value representation), it emits a warning but
-            # not provide the tag and value that caused the warning.
+            # does not provide the tag and value that caused the warning.
             # We will handle it later (optionally) by calling validate_value
             # directly.
             config.settings.reading_validation_mode = config.IGNORE


### PR DESCRIPTION
Fix for issue #105 
- Suppressed pydicom's warnings coming from `dcmread`
- Replaced `exit` with `sys.exit`, since the primary usage is within a program (Reference: [stackoverflow](https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python))
- Updated `changes.md` with correct version number