### PR TITLE
Build executables using pyinstaller on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,10 @@ The released versions correspond to PyPi releases.
 ### Features
 * iod_validator: added validation of values against value representations, with
   a new option `-svr` to suppress the above check
+* Infrastructure for building executable using `pyinstaller` on Windows
 
 ### Fixes
-* dump_dcm_info: suppressed invalid value warnings from dicomread
+* dump_dcm_info: suppressed invalid value warnings from dcmread
 
 ## [Version 0.5.1](https://pypi.python.org/pypi/dicom-validator/0.5.1) (2024-04-06)
 Fixes for enum checks.

--- a/README.md
+++ b/README.md
@@ -185,3 +185,22 @@ c:\dev\DICOM Data\SR\image12.dcm
 (0010,0010) Patient's Name                           ON    1  [DOE^JANE]
 (0010,0020) Patient ID                               LO    1  [ACN000001]
 ```
+
+## Build executable on Windows
+
+Here is a sample workflow:
+```powershell
+# Clone the repository
+git clone git@github.com:pydicom/dicom-validator.git
+
+# Create a virtual environment and activate it
+cd dicom-validator
+virtualenv venv
+venv\Scripts\activate
+
+# Install dependencies for development
+pip install -r requirements-dev.txt
+
+# Build executables. They will be placed in the `dist` subfolder.
+pyinstaller dicom-validator.spec -y
+```

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,3 @@
 [default.extend-words]
 acn = "ACN"
+datas = "datas"

--- a/dicom-validator.spec
+++ b/dicom-validator.spec
@@ -1,0 +1,81 @@
+# This file tells PyInstaller how to compile.
+# From PowerShell prompt, use "build.ps1 exe"
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_all
+
+datas = []
+binaries = []
+hiddenimports = []
+hiddenimports += collect_submodules('pydicom')
+tmp_ret = collect_all('lxml')
+datas += tmp_ret[0];  hiddenimports += tmp_ret[2]
+
+validate_iods_a = Analysis(
+    ['dicom_validator/validate_iods.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+dump_dcm_info_a = Analysis(
+    ['dicom_validator/dump_dcm_info.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+
+validate_iods_pyz = PYZ(validate_iods_a.pure)
+
+validate_iods_exe = EXE(
+    validate_iods_pyz,
+    validate_iods_a.scripts,
+    validate_iods_a.binaries,
+    validate_iods_a.datas,
+    [],
+    name='validate_iods',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+dump_dcm_info_pyz = PYZ(dump_dcm_info_a.pure)
+
+dump_dcm_info_exe = EXE(
+    dump_dcm_info_pyz,
+    dump_dcm_info_a.scripts,
+    dump_dcm_info_a.binaries,
+    dump_dcm_info_a.datas,
+    [],
+    name='dump_dcm_info',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/dicom-validator.spec
+++ b/dicom-validator.spec
@@ -1,5 +1,7 @@
 # This file tells PyInstaller how to compile.
-# From PowerShell prompt, use "build.ps1 exe"
+# From PowerShell prompt, use:
+# pyinstaller dicom-validator.spec -y
+
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_submodules
 from PyInstaller.utils.hooks import collect_all

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,11 @@
+black
+mypy
+pre-commit
 pydicom>=2.3.0
 pyfakefs>=3.4.1
 pyinstaller
 pytest
 pytest-cov
 pytest-order
+ruff
+typos

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pydicom>=2.3.0
 pyfakefs>=3.4.1
+pyinstaller
 pytest
 pytest-cov
 pytest-order

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-black
-mypy
 pre-commit
 pydicom>=2.3.0
 pyfakefs>=3.4.1
@@ -7,5 +5,3 @@ pyinstaller
 pytest
 pytest-cov
 pytest-order
-ruff
-typos


### PR DESCRIPTION
Fix for issue #104
- Added pyinstaller dependency for development
- Added spec file for `pyinstaller` to build executables
- Added instructions in README.md
- Updated change log