### PR TITLE
Added workflow to build executable on GitHub

### DIFF
--- a/.github/workflows/build_windows_exe.yml
+++ b/.github/workflows/build_windows_exe.yml
@@ -1,0 +1,44 @@
+name: build-windows-exe
+
+on:
+  pull_request:
+
+  # TODO: Add a release event to trigger the workflow
+  # release:
+  #   types: [ published ]
+
+jobs:
+
+  deploy:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ '3.10' ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Build package
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-dev.txt
+        python -m build
+        pyinstaller dicom-validator.spec -y
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows_exe
+        path: dist/*.exe
+    # TODO: How to Publish?
+    # - name: Publish package to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}


### PR DESCRIPTION
- Build executable as GitHub workflow, as conclusion of issue #104 
- The workflow is triggered by a pull request. We may want to add additional triggers. I am not sure how.
- The artifacts of the pull requests are archived into a zip file. There may be better ways, but I don't know how!