### PR TITLE
Release windows executable as part of release-deploy

### DIFF
--- a/.github/workflows/build_windows_exe.yml
+++ b/.github/workflows/build_windows_exe.yml
@@ -2,10 +2,9 @@ name: build-windows-exe
 
 on:
   pull_request:
-
-  # TODO: Add a release event to trigger the workflow
-  # release:
-  #   types: [ published ]
+    # This workflow is to make sure that the Windows executables are built correctly.
+    # The artifacts are for this pull request only.
+    # The 'release' versions of artifacts are deployed from the release-deploy workflow.
 
 jobs:
 
@@ -36,9 +35,4 @@ jobs:
       with:
         name: windows_exe
         path: dist/*.exe
-    # TODO: How to Publish?
-    # - name: Publish package to PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}
+    #

--- a/.github/workflows/build_windows_exe.yml
+++ b/.github/workflows/build_windows_exe.yml
@@ -35,4 +35,3 @@ jobs:
       with:
         name: windows_exe
         path: dist/*.exe
-    #

--- a/.github/workflows/build_windows_exe.yml
+++ b/.github/workflows/build_windows_exe.yml
@@ -1,0 +1,44 @@
+name: build-windows-exe
+
+on:
+  pull_request:
+
+  # TODO: Add a release event to trigger the workflow
+  # release:
+  #   types: [ published ]
+
+jobs:
+
+  deploy:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ '3.10' ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Build package
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-dev.txt
+        python -m build
+        pyinstaller dicom-validator.spec -y
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows_exe
+        path: dist/*.exe
+    # TODO: How to Publish?
+    # - name: Publish package to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install build
+        python -m pip install -r requirements-dev.txt
         python -m build
         pyinstaller dicom-validator.spec -y
 

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,10 +1,8 @@
 name: release-deploy
 
 on:
-  pull_request:
-
-  # release:
-  #   types: [ published ]
+  release:
+    types: [ published ]
 
 jobs:
 
@@ -16,7 +14,7 @@ jobs:
         os: [  'ubuntu-latest', 'windows-latest' ]
 
     runs-on: ${{ matrix.os }}
-    name: Deploy to ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    name: Deploy for ${{ matrix.os }} with Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -30,21 +28,25 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install build
-        python -m pip install -r requirements-dev.txt
         python -m build
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}
+
+    - name: Build Windows executables
+      if: matrix.os == 'windows-latest'
+      run: |
+        python -m pip install -r requirements-dev.txt
         pyinstaller dicom-validator.spec -y
 
-    # - name: Publish package to PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}
-
     - name: Publish Windows executables on GitHub
+      if: matrix.os == 'windows-latest'
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: matrix.os == 'windows-latest'
       with:
         files: |
           - dist/validate_iods.exe

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         python -m build
 
     - name: Publish package to PyPI
+      if: matrix.os == 'ubuntu-latest'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,17 +1,22 @@
 name: release-deploy
 
 on:
-  release:
-    types: [ published ]
+  pull_request:
+
+  # release:
+  #   types: [ published ]
 
 jobs:
 
   deploy:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         python-version: [ '3.10' ]
+        os: [  'ubuntu-latest', 'windows-latest' ]
+
+    runs-on: ${{ matrix.os }}
+    name: Deploy to ${{ matrix.os }} with Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -26,9 +31,20 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install build
         python -m build
+        pyinstaller dicom-validator.spec -y
 
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+    # - name: Publish package to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}
+
+    - name: Publish Windows executables on GitHub
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: matrix.os == 'windows-latest'
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN_VALIDATOR }}
+        files: |
+          - dist/validate_iods.exe
+          - dist/dump_dcm_info.exe


### PR DESCRIPTION
- Added a new workflow to build executables on Windows when a pull request is opened
- For windows only, added steps to build and deploy windows executables to GitHub release.
- If this PR looks good, it can replace PR #108.