### PR TITLE
Partly fix parsing of Graphic Annotation condition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ The released versions correspond to PyPi releases.
 
 ### Fixes
 * Fixed `(0070,0024) Graphic Filled` condition (see [#115](../../issues/115)).
+* Fixed a case of mixed ORed values and conditions.
+* Handle ", that is " clause in condition.
 
 ## [Version 0.6.0](https://pypi.python.org/pypi/dicom-validator/0.6.0) (0.6.0)
 Adds Windows executable to GitHub release.

--- a/dicom_validator/spec_reader/part3_reader.py
+++ b/dicom_validator/spec_reader/part3_reader.py
@@ -8,6 +8,7 @@ import logging
 from itertools import groupby
 
 import sys
+from typing import Dict
 
 from dicom_validator.spec_reader.condition import (
     Condition,
@@ -24,22 +25,10 @@ from dicom_validator.spec_reader.spec_reader import (
 
 
 # Some conditions from the spec are hard to parse with a few general rules.
-# Instead of implementing a full parser for these cases, we define them here.
-SPECIAL_CASES = {
-    # (0070,0024) Graphic Filled condition:
-    #       Required if Graphic Data (0070,0022) is "closed",
-    #       that is Graphic Type (0070,0023) is CIRCLE or ELLIPSE,
-    #       or Graphic Type (0070,0023) is POLYLINE or INTERPOLATED
-    #       and the first data point is the same as the last data point.
-    # The second part of the condition is not possible to implement with
-    # the current implementation, so it is ignored instead.
-    "(0070,0024)": Condition(
-        ctype=ConditionType.MandatoryOrUserDefined,
-        operator=ConditionOperator.EqualsValue,
-        tag="(0070,0023)",
-        values=["CIRCLE", "ELLIPSE"],
-    ),
-}
+# Instead of implementing a full parser for these cases, we may define them here.
+# CAUTION: The same tag may appear with different conditions in different contexts
+# (different sequences), which will not be handled automatically by SPECIAL_CASES
+SPECIAL_CASES: Dict[str, Condition] = {}
 
 
 class Part3Reader(SpecReader):

--- a/dicom_validator/tests/spec_reader/test_part3_reader.py
+++ b/dicom_validator/tests/spec_reader/test_part3_reader.py
@@ -246,15 +246,13 @@ class TestReadPart3:
         assert "(0070,0001)" in description
         assert "items" in description["(0070,0001)"]
 
-        graphic_object_sequence = "(0070,0009)"
-        compound_graphic_sequence = "(0070,0209)"
-        for sequence_tag in (graphic_object_sequence, compound_graphic_sequence):
-            assert sequence_tag in description["(0070,0001)"]["items"]
-            sequence = description["(0070,0001)"]["items"][sequence_tag]
-            graphic_filled_cond = sequence["items"]["(0070,0024)"]["cond"]
-            assert graphic_filled_cond.type == ConditionType.MandatoryOrUserDefined
-            assert graphic_filled_cond.operator == ConditionOperator.EqualsValue
-            assert graphic_filled_cond.values == ["CIRCLE", "ELLIPSE"]
-            assert graphic_filled_cond.and_conditions == []
-            assert graphic_filled_cond.or_conditions == []
-            assert graphic_filled_cond.other_condition is None
+        sequence_tag = "(0070,0009)"  # Graphic Object Sequence
+        assert sequence_tag in description["(0070,0001)"]["items"]
+        sequence = description["(0070,0001)"]["items"][sequence_tag]
+        graphic_filled_cond = sequence["items"]["(0070,0024)"]["cond"]
+        assert graphic_filled_cond.type == ConditionType.MandatoryOrUserDefined
+        assert graphic_filled_cond.operator == ConditionOperator.EqualsValue
+        assert graphic_filled_cond.values == ["CIRCLE", "ELLIPSE"]
+        assert graphic_filled_cond.and_conditions == []
+        assert graphic_filled_cond.or_conditions == []
+        assert graphic_filled_cond.other_condition is None

--- a/dicom_validator/tests/validator/test_iod_validator_func_groups.py
+++ b/dicom_validator/tests/validator/test_iod_validator_func_groups.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from pydicom import Sequence
+from pydicom import Sequence, uid
 from pydicom.dataset import Dataset, FileMetaDataset
 
 from dicom_validator.tests.utils import has_tag_error
@@ -13,8 +13,7 @@ pytestmark = pytest.mark.usefixtures("disable_logging")
 def new_data_set(shared_macros, per_frame_macros):
     """Create a DICOM data set with the given attributes"""
     data_set = Dataset()
-    # Enhanced X-Ray Angiographic Image
-    data_set.SOPClassUID = "1.2.840.10008.5.1.4.1.1.12.1.1"
+    data_set.SOPClassUID = uid.EnhancedXAImageStorage
     data_set.PatientName = "XXX"
     data_set.PatientID = "ZZZ"
     data_set.ImageType = "DERIVED\\SECONDARY"
@@ -101,7 +100,8 @@ PIXEL_MEASURES = {"PixelMeasuresSequence": [{"PixelSpacing": "0.1\\0.1"}]}
 class TestIODValidatorFuncGroups:
     """Tests IODValidator for functional groups."""
 
-    def ensure_group_result(self, result):
+    @staticmethod
+    def ensure_group_result(result):
         assert "Multi-frame Functional Groups" in result
         return result["Multi-frame Functional Groups"]
 
@@ -168,8 +168,7 @@ class TestIODValidatorFuncGroups:
     @pytest.mark.shared_macros([])
     @pytest.mark.per_frame_macros([PIXEL_MEASURES])
     def test_macro_not_allowed_in_per_frame_group(self, validator):
-        # VL Whole Slide Microscopy Image IOD
-        validator._dataset.SOPClassUID = "1.2.840.10008.5.1.4.1.1.77.1.6"
+        validator._dataset.SOPClassUID = uid.VLWholeSlideMicroscopyImageStorage
         result = validator.validate()
         # Frame Anatomy Sequence (present in shared groups)
         assert has_tag_error(result, "Pixel Measures", "(0028,9110)", "not allowed")

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -588,9 +588,13 @@ class IODValidator:
         tag = Tag(tag_id)
         return str(tag).replace(" ", "")
 
-    @staticmethod
-    def _tag_matches(tag_value, operator, values):
-        values = [type(tag_value)(value) for value in values]
+    def _tag_matches(self, tag_value, operator, values):
+        try:
+            values = [type(tag_value)(value) for value in values]
+        except ValueError:
+            self.logger.debug(f"type for '{values}' does not match '{tag_value}'")
+            # the values are of the wrong type - ignore them
+            return False
         if operator == ConditionOperator.EqualsValue:
             return tag_value in values
         if operator == ConditionOperator.NotEqualsValue:


### PR DESCRIPTION
- handle ", that is" phrase
- handle mixed ORed values and conditions
- catch incorrectly parsed value type
- remove now unneeded special case

@drahoja9 - please have a look. I reverted some of your changes, as the special handling is no longer needed, but let the mechanism in place.