### PR TITLE
Add missing bounds check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Dicom Validator Release Notes
 The released versions correspond to PyPi releases.
 
+## Unreleased
+
+### Fixes
+* Fixed a regression bug introduced in 0.6.1, leading to an exception during docbook parsing
+  (see [#119](../../issues/119)).
+
 ## [Version 0.6.1](https://pypi.python.org/pypi/dicom-validator/0.6.1) (2024-08-05)
 Some condition parser fixes.
 

--- a/dicom_validator/spec_reader/condition_parser.py
+++ b/dicom_validator/spec_reader/condition_parser.py
@@ -350,6 +350,8 @@ class ConditionParser:
 
     def _get_const_value(self, value: str) -> Tuple[Optional[str], str]:
         value = value.strip()
+        if not value:
+            return None, ""
         if value[0] == value[-1] == '"':
             return value[1:-1], ""
         if re.match("^[A-Z0-9][A-Za-z0-9_ ]*$", value) is not None:

--- a/dicom_validator/tests/spec_reader/test_condition_parser.py
+++ b/dicom_validator/tests/spec_reader/test_condition_parser.py
@@ -955,3 +955,12 @@ class TestComplicatedConditionParser:
         ]
         other_cond = result.other_condition
         assert other_cond is None
+
+    def test_empty_value_handled(self, parser):
+        # regression test for an exception that happened due to a wrongly
+        # read in condition, see #119
+        result = parser.parse(
+            "Required if segmented data is NOT used in an Image IOD "
+            "or , or if the IOD is a Presentation State IOD."
+        )
+        assert result.type == ConditionType.UserDefined


### PR DESCRIPTION
- prevents an exception during parsing
- the root cause is a problem with the parser which creates incorrect output, the reason is still unknown
- fixes #119