### PR TITLE
Support values of type list in addition to MultiValue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # Dicom Validator Release Notes
 The released versions correspond to PyPi releases.
 
+## Version TBD
+
+### Fixes
+* support values of type list in addition to MultiValue (see [#165](../../issues/165))
+
 ### Infrastructure
 * update the tests for current version 2025a
 

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -394,7 +394,7 @@ class IODValidator:
                 if value is None or isinstance(value, (Sequence, str)) and not value:
                     error_kind = "empty"
             if value is not None and (not isinstance(value, str) or value):
-                if not isinstance(value, MultiValue):
+                if not isinstance(value, (MultiValue, list)):
                     value = [value]
                 for i, v in enumerate(value):
                     if "enums" in attribute:


### PR DESCRIPTION
Prior to [pydicom PR 2217](https://github.com/pydicom/pydicom/pull/2217), pydicom
may show the value type for some tags as `list` instead of `MultiValue`. Validation converted
such values to "list of list" before this change and flagged them as invalid. This change
treats values of type `list` same as `MultiValue`. See issue #165 for more details.  