### PR TITLE
Remove Python 3.8, add Python 3.14 to CI

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -13,17 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          # exclude while some tests fail due to a known issue in pyfakefs
-          - python-version: "3.13"
-            os: macOS-latest
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Cache DICOM standard
         id: cache-dicom

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,15 @@ The released versions correspond to PyPi releases.
 
 ## Version TBD
 
+### Changes
+* Python 3.8 has reached EOL and is no longer officially supported
+
 ### Fixes
 * support values of type list in addition to MultiValue (see [#165](../../issues/165))
 
 ### Infrastructure
 * update the tests for current version 2025a
+* remove Python 3.18, add Python 3.14 to CI (needs development version of `pydicom`)
 
 ## [Version 0.6.4](https://pypi.python.org/pypi/dicom-validator/0.6.4) (2024-12-19)
 Bugfix release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -26,13 +25,17 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
-dependencies = ["pydicom", "lxml"]
+dependencies = [
+    "pydicom; python_version < '3.14'",
+    "pydicom@git+https://github.com/pydicom/pydicom ; python_version >= '3.14'",
+    "lxml; python_version < '3.14'"
+]
 description = "Python DICOM validator using input from DICOM specs in docbook format"
 keywords = ["dicom, python"]
 license = {text = "MIT"}
 name = "dicom-validator"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pydicom>=2.3.0
-lxml
+pydicom>=2.3.0 ; python_version < "3.14"
+pydicom@git+https://github.com/pydicom/pydicom ; python_version >= "3.14"
+lxml ; python_version < "3.14"


### PR DESCRIPTION
- Python 3.8 is EOL
- Python 3.14 needs development version of pydicom