### PR TITLE
Find deeper nested IODs and group macros

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
+### Changes
+* the error message for tags not allowed in Shared or Per-Frame Functional Groups
+  has been made more specific
+
 ### Fixes
 * several IODs in newer DICOM versions (17 out of 174) have not been parsed
 * some of the IOD-specific group macros (4 of 27) have not been found

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
+### Fixes
+* several IODs in newer DICOM versions (17 out of 174) have not been parsed
+* some of the IOD-specific group macros (4 of 27) have not been found
+  (see [#193](../../issues/193))
+
 ### Infrastructure
 * updated the tests for current DICOM version 2025c
 * added Python 3.14 to CI (needs development version of `pydicom`)

--- a/dicom_validator/spec_reader/part3_reader.py
+++ b/dicom_validator/spec_reader/part3_reader.py
@@ -139,7 +139,7 @@ class Part3Reader(SpecReader):
             nodes_with_subnodes = []
             for iod_node in all_iod_nodes:
                 sub_nodes = self._find_sections_with_title_endings(
-                    iod_node, iod_def_endings
+                    iod_node, iod_def_endings, depth=2
                 )
                 if sub_nodes:
                     nodes_with_subnodes.append(iod_node)
@@ -385,13 +385,13 @@ class Part3Reader(SpecReader):
     def _get_functional_group_macros(self, iod_node):
         macros = {}
         group_macro_sections = self._find_sections_with_title_endings(
-            iod_node, (" Functional Group Macros",)
+            iod_node, (" Functional Group Macros",), depth=1
         )
         if len(group_macro_sections) == 1:
             macros = self._collect_modules(group_macro_sections[0], check_rowspan=False)
         return macros
 
-    def _find_sections_with_title_endings(self, node, title_endings):
+    def _find_sections_with_title_endings(self, node, title_endings, depth=0):
         section_nodes = self._findall(node, ["section"])
         found_nodes = []
         for sections_node in section_nodes:
@@ -402,4 +402,10 @@ class Part3Reader(SpecReader):
                     [title.endswith(title_ending) for title_ending in title_endings]
                 ):
                     found_nodes.append(sections_node)
+            if depth > 0:
+                found_nodes.extend(
+                    self._find_sections_with_title_endings(
+                        sections_node, title_endings, depth=depth - 1
+                    )
+                )
         return found_nodes

--- a/dicom_validator/tests/spec_reader/test_part3_reader.py
+++ b/dicom_validator/tests/spec_reader/test_part3_reader.py
@@ -90,7 +90,7 @@ class TestReadPart3:
 
     @pytest.mark.parametrize(
         "revision,desc_nr",
-        [("2015b", 110), ("2025c", 157)],
+        [("2015b", 110), ("2025c", 174)],
         indirect=["revision"],
         scope="session",
     )
@@ -134,6 +134,24 @@ class TestReadPart3:
         assert condition.operator == ConditionOperator.EqualsValue
         assert condition.tag == "(0008,0008)"
         assert condition.values == ["ORIGINAL", "MIXED"]
+
+    def test_nested_group_macros(self, reader):
+        descriptions = reader.iod_descriptions()
+        # the Ophthalmic Optical Coherence Tomography B-scan Volume Analysis IOD
+        # is found at a level below the usual one
+        macros = descriptions["A.84"]["group_macros"]
+        assert len(macros) == 9
+
+        # the RT Second Generation IODs are at a lower level than usual
+        assert "A.86.1.14" in descriptions
+        macros = descriptions["A.86.1.14"]["group_macros"]
+        assert not macros
+        assert "A.86.1.15" in descriptions
+        macros = descriptions["A.86.1.15"]["group_macros"]
+        assert len(macros) == 16
+        assert "A.86.1.16" in descriptions
+        macros = descriptions["A.86.1.16"]["group_macros"]
+        assert len(macros) == 16
 
     @pytest.mark.parametrize(
         "revision,desc_nr",
@@ -183,7 +201,7 @@ class TestReadPart3:
 
     @pytest.mark.parametrize(
         "revision,desc_nr",
-        [("2015b", 451), ("2025c", 592)],
+        [("2015b", 452), ("2025c", 667)],
         indirect=["revision"],
         scope="session",
     )

--- a/dicom_validator/tests/validator/test_iod_validator_func_groups.py
+++ b/dicom_validator/tests/validator/test_iod_validator_func_groups.py
@@ -166,7 +166,9 @@ class TestIODValidatorFuncGroups:
     def test_macro_not_allowed_in_shared_group(self, validator):
         result = validator.validate()
         # Frame Anatomy Sequence (present in shared groups)
-        assert has_tag_error(result, "Frame Content", "(0020,9111)", "not allowed")
+        assert has_tag_error(
+            result, "Frame Content", "(0020,9111)", "not allowed in Shared Group"
+        )
 
     @pytest.mark.shared_macros([])
     @pytest.mark.per_frame_macros([PIXEL_MEASURES])

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -224,10 +224,13 @@ class IODValidator:
                 is_per_frame = self._in_per_frame_group
 
         allowed = True
+        msg_postfix = ""
         if condition and "F" in condition["type"] and is_shared:
             required, allowed = False, False
+            msg_postfix = " in Shared Group"
         elif condition and "S" in condition["type"] and is_per_frame:
             required, allowed = False, False
+            msg_postfix = " in Per-Frame Group"
         elif usage[0] == "M":
             required = True
         elif usage[0] == ConditionType.UserDefined:
@@ -280,7 +283,9 @@ class IODValidator:
             for tag_id_string in module_info:
                 tag_id = self._tag_id(tag_id_string)
                 if tag_id in self._dataset_stack[-1].dataset:
-                    message = self._incorrect_tag_message(tag_id, "not allowed")
+                    message = self._incorrect_tag_message(
+                        tag_id, "not allowed" + msg_postfix
+                    )
                     errors.setdefault(message, []).append(tag_id_string)
             return errors
         return self._validate_attributes(module_info, False)
@@ -652,7 +657,7 @@ class IODValidator:
     def _tag_context_message(self):
         if len(self._dataset_stack) > 1:
             m = " > ".join([item.name for item in self._dataset_stack])
-            context = f" in  {m}"
+            context = f" in {m}"
             return context
         return ""
 


### PR DESCRIPTION
- several newer IODs are in sub-chapters (like A.86.1.15)
- 2 group macro definitions are at a level below the usual one
- fixes #193
