### PR TITLE
Use BaseTag instead of int for tags

### DIFF
--- a/dicom_validator/spec_reader/condition.py
+++ b/dicom_validator/spec_reader/condition.py
@@ -1,6 +1,8 @@
 import enum
 from typing import Optional, Any, Union
 
+from pydicom.tag import BaseTag
+
 from dicom_validator.tag_tools import tag_name_from_id
 
 
@@ -246,7 +248,9 @@ class Condition:
         elif self.operator == ConditionOperator.Absent:
             result += " is not present"
         elif self.operator == ConditionOperator.EqualsTag:
-            result += f" points to {tag_name_from_id(int(self.values[0]), dict_info)}"
+            result += (
+                f" points to {tag_name_from_id(BaseTag(self.values[0]), dict_info)}"
+            )
         elif not self.values:
             # if no values are found here, we have some unhandled condition
             # and ignore it for the time being

--- a/dicom_validator/tag_tools.py
+++ b/dicom_validator/tag_tools.py
@@ -1,12 +1,11 @@
+from pydicom.tag import BaseTag
+
+
 def tag_name_from_id_string(tag_id: str, dict_info: dict | None) -> str:
     if dict_info and tag_id in dict_info:
         return f'{tag_id} ({dict_info[tag_id]["name"]})'
     return tag_id
 
 
-def tag_id_string(tag_id: int) -> str:
-    return f"({tag_id // 0x10000:04X},{tag_id % 0x10000:04X})"
-
-
-def tag_name_from_id(tag_id: int, dict_info: dict | None) -> str:
-    return tag_name_from_id_string(tag_id_string(tag_id), dict_info)
+def tag_name_from_id(tag_id: BaseTag, dict_info: dict | None) -> str:
+    return tag_name_from_id_string(str(tag_id), dict_info)

--- a/dicom_validator/tests/validator/test_iod_validator_func_groups.py
+++ b/dicom_validator/tests/validator/test_iod_validator_func_groups.py
@@ -182,8 +182,8 @@ class TestIODValidatorFuncGroups:
 
         messages = [rec.message for rec in caplog.records]
         assert '\nModule "Irradiation Event Identification":' in messages
+        assert "(5200,9229) (Shared Functional Groups Sequence):" in messages
         assert (
-            "(5200,9229) (Shared Functional Groups Sequence):\n"
             "  Tag (0018,9477) (Irradiation Event Identification Sequence) is missing"
             in messages
         )
@@ -203,10 +203,10 @@ class TestIODValidatorFuncGroups:
 
         messages = [rec.message for rec in caplog.records]
         assert '\nModule "Frame Anatomy":' in messages
+        assert "(5200,9230) (Per-Frame Functional Groups Sequence):" in messages
         assert (
-            "(5200,9230) (Per-Frame Functional Groups Sequence):\n"
-            "  Tag (0020,9071) (Frame Anatomy Sequence) is not allowed in both Shared and Per-Frame Groups"
-            in messages
+            "  Tag (0020,9071) (Frame Anatomy Sequence) is not allowed "
+            "in both Shared and Per-Frame Groups" in messages
         )
 
     @pytest.mark.shared_macros([FRAME_CONTENT])
@@ -240,8 +240,8 @@ class TestIODValidatorFuncGroups:
 
         messages = [rec.message for rec in caplog.records]
         assert '\nModule "Frame Content":' in messages
+        assert "(5200,9229) (Shared Functional Groups Sequence):" in messages
         assert (
-            "(5200,9229) (Shared Functional Groups Sequence):\n"
             "  Tag (0020,9111) (Frame Content Sequence) is not allowed in Shared Group"
             in messages
         )
@@ -259,8 +259,8 @@ class TestIODValidatorFuncGroups:
 
         messages = [rec.message for rec in caplog.records]
         assert '\nModule "Pixel Measures":' in messages
+        assert "(5200,9230) (Per-Frame Functional Groups Sequence):" in messages
         assert (
-            "(5200,9230) (Per-Frame Functional Groups Sequence):\n"
             "  Tag (0028,9110) (Pixel Measures Sequence) is not allowed in Per-Frame Group"
             in messages
         )


### PR DESCRIPTION
- this is derived from int and has already the needed convenience
- adapt error handling to group tags inside the same sequence
- add more typing

See #205, ongoing work.