### PR TITLE
Add support for recursive references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ In line with pydicom, support for Python 3.9 will be removed in that version.
 ### Fixes
 * tags not allowed in multi-frame functional groups have been listed
   as errors twice (see [#196](../../issues/196))
+* fixes to correctly evaluate SR documents (see [#206](../../issues/206)):
+  * sequences defined recursively in the standard are now supported
+  * conditions for including macros inside a sequence are now evaluated on the correct level
 
 ### Infrastructure
 * added Python 3.14 to CI (currently needs development version of `pydicom`)

--- a/dicom_validator/tests/validator/test_iod_validator.py
+++ b/dicom_validator/tests/validator/test_iod_validator.py
@@ -15,10 +15,10 @@ from dicom_validator.validator.validation_result import Status, ErrorCode
 pytestmark = pytest.mark.usefixtures("disable_logging")
 
 
-def new_data_set(tags, ds: Dataset | None = None):
+def new_data_set(tags, *, top_level: bool = True):
     """Create a DICOM data set with the given attributes"""
     tags = tags or {}
-    data_set = ds or Dataset()
+    data_set = Dataset()
     if not tags:
         return data_set
     for tag, value in tags.items():
@@ -30,9 +30,13 @@ def new_data_set(tags, ds: Dataset | None = None):
         if vr == "SQ":
             items = []
             for item_tags in value:
-                items.append(new_data_set(item_tags, data_set))
+                items.append(new_data_set(item_tags, top_level=False))
             value = Sequence(items)
         data_set[tag] = DataElement(tag, vr, value)
+    if not top_level:
+        # this is a sequence item
+        return data_set
+
     # write the dataset into a file and read it back to ensure the real behavior
     if "SOPInstanceUID" not in data_set:
         data_set.SOPInstanceUID = "1.2.3"
@@ -759,3 +763,38 @@ class TestIODValidator:
             "values": ["closed"],
         }
         assert validator.validate()
+
+    @pytest.mark.tag_set(
+        {
+            "SOPClassUID": uid.ComprehensiveSRStorage,
+            "ValueType": "CONTAINER",
+            "ContinuityOfContent": "SEPARATE",
+            "ContentSequence": [
+                {
+                    "RelationshipType": "CONTAINS",
+                    "ValueType": "CONTAINER",
+                    "ContinuityOfContent": "SEPARATE",
+                    "ContentSequence": [
+                        {
+                            "RelationshipType": "HAS OBS CONTEXT",
+                            "ValueType": "UIDREF",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    def test_recursive_reference(self, validator):
+        # regression test for #206
+        # Content Sequence (0040,A730) is defined recursively in SR Document Content
+        # and is allowed inside another Content Sequence item
+        result = validator.validate()
+        assert not has_tag_error(
+            result, "SR Document Content", 0x0040_A730, ErrorCode.TagUnexpected
+        )
+        # Continuity Of Content (0040,A050) is present with ValueType "CONTAINER",
+        # but not with ValueType "UIDREF";
+        # this is correct, so no error shall be shown for Continuity Of Content
+        assert not has_tag_error(
+            result, "SR Document Content", 0x0040_A050, ErrorCode.TagMissing
+        )

--- a/dicom_validator/tests/validator/test_iod_validator_func_groups.py
+++ b/dicom_validator/tests/validator/test_iod_validator_func_groups.py
@@ -29,6 +29,12 @@ def new_data_set(shared_macros, per_frame_macros):
     data_set.ContentDate = "20000101"
     data_set.ContentTime = "120000"
     data_set.NumberOfFrames = "3"
+    mask_subtraction_seq = Sequence()
+    item = Dataset()
+    item.MaskOperation = "AVG_SUB"
+    mask_subtraction_seq.append(item)
+    data_set.MaskSubtractionSequence = mask_subtraction_seq
+
     shared_groups = Sequence()
     if shared_macros:
         item = Dataset()
@@ -179,6 +185,11 @@ class TestIODValidatorFuncGroups:
         assert not has_tag_error(
             result, "Referenced Image", 0x0008_1140, ErrorCode.TagMissing
         )
+
+        # Subtraction Item ID, required because of the SOP Class UID value (in dataset root)
+        assert has_tag_error(result, "Mask", 0x0028_9416, ErrorCode.TagMissing)
+        # Mask Frame Numbers, required because Mask Operation (inside the sequence item) is AVG_SUB
+        assert has_tag_error(result, "Mask", 0x0028_6110, ErrorCode.TagMissing)
 
         messages = [rec.message for rec in caplog.records]
         assert '\nModule "Irradiation Event Identification":' in messages

--- a/dicom_validator/validator/validation_result.py
+++ b/dicom_validator/validator/validation_result.py
@@ -56,6 +56,10 @@ class DicomTag:
     tag: BaseTag
     parents: list[BaseTag] | None = None
 
+    def __init__(self, tag: int, parents: list[int] | None = None):
+        self.tag = BaseTag(tag)
+        self.parents = [BaseTag(p) for p in parents] if parents else None
+
     def __hash__(self):
         return hash(self.tag + (sum(self.parents) if self.parents else 0))
 


### PR DESCRIPTION
- evaluate conditions in sequences lazily to make sure to check the correct dataset
- this also allows recursively defined sequence attributes

Fixes #206. Structured Reports should now be correctly handled.