### PR TITLE
Handle invalid sequence VR as a validation error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 The released versions correspond to PyPi releases.
 `dicom-validator` versions follow [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changes
+* an invalid sequence (incorrect VR) is now handled as a validation error
+  instead of raising a `RuntimeError` (see [#288](https://github.com/pydicom/dicom-validator/issues/288))
+
 ## [Version 0.8.2](https://pypi.python.org/pypi/dicom-validator/0.8.2) (2026-04-12)
 Fixes Windows executable and API documentation.
 

--- a/dicom_validator/tests/validator/conftest.py
+++ b/dicom_validator/tests/validator/conftest.py
@@ -94,6 +94,9 @@ def new_data_set(tags, *, top_level: bool = True):
         return data_set
     for tag, value in tags.items():
         tag = Tag(tag)  # raises for invalid tag
+        if isinstance(value, DataElement):
+            data_set[tag] = value
+            continue
         try:
             vr = dictionary_VR(tag)
         except KeyError:

--- a/dicom_validator/tests/validator/test_iod_validator.py
+++ b/dicom_validator/tests/validator/test_iod_validator.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from pydicom import uid
+from pydicom import DataElement, uid
 
 from dicom_validator.tests.utils import has_tag_error
 from dicom_validator.validator.validation_result import ErrorCode, Status
@@ -122,6 +122,31 @@ class TestIODValidator:
         assert '\nModule "Patient":' in messages
         assert (
             "Tag (0010,0022) (Type of Patient ID) has invalid value 'lowercase' for VR CS"
+            in messages
+        )
+
+    @pytest.mark.tag_set(
+        {
+            "SOPClassUID": uid.CTImageStorage,
+            "DerivationCodeSequence": DataElement(
+                "DerivationCodeSequence", "OB", b"\x00" * 10
+            ),
+        }
+    )
+    def test_invalid_sequence(self, validator, caplog):
+        caplog.set_level(logging.WARNING)
+        result = validator.validate()
+
+        assert result.status == Status.Failed
+        assert "General Reference" in result.module_errors
+        assert has_tag_error(
+            result, "General Reference", 0x0008_9215, ErrorCode.InvalidSequence
+        )
+
+        messages = [rec.message for rec in caplog.records]
+        assert '\nModule "General Reference":' in messages
+        assert (
+            "Tag (0008,9215) (Derivation Code Sequence) is not a valid sequence, ignoring it"
             in messages
         )
 

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -219,6 +219,8 @@ class LoggingResultHandler(ValidationResultHandlerBase):
             case ErrorCode.InvalidValue:
                 error.context = error.context or {}
                 return f" has invalid value '{error.context['value']}' for VR {error.context['VR'] if error.context else ''}"
+            case ErrorCode.InvalidSequence:
+                return " is not a valid sequence, ignoring it"
             case _:
                 return ""
 

--- a/dicom_validator/validator/html_error_handler.py
+++ b/dicom_validator/validator/html_error_handler.py
@@ -155,6 +155,8 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
                     vr = error.context.get("VR", "")
                     info = f" '{value}' for VR {vr}"
                 return f" has invalid value{info}"
+            case ErrorCode.InvalidSequence:
+                return " is not a valid sequence"
             case _:
                 return ""
 

--- a/dicom_validator/validator/iod_validator.py
+++ b/dicom_validator/validator/iod_validator.py
@@ -370,7 +370,8 @@ class IODValidator:
                     if data_elem is None:
                         continue
                     if data_elem.VR != "SQ":
-                        raise RuntimeError(f"Not a sequence: {data_elem}")
+                        errors[tag_id] = TagError(code=ErrorCode.InvalidSequence)
+                        continue
                     for sq_item_dataset in data_elem.value:
                         self._dataset_stack.append(
                             DatasetStackItem(

--- a/dicom_validator/validator/validation_result.py
+++ b/dicom_validator/validator/validation_result.py
@@ -20,6 +20,8 @@ class ErrorCode(enum.Enum):
     """Value not in the list of allowed enum values"""
     InvalidValue = 6
     """The value failed the VR validation"""
+    InvalidSequence = 7
+    """Invalid DICOM sequence"""
 
 
 class ErrorScope(enum.Enum):

--- a/doc/source/validation.rst
+++ b/doc/source/validation.rst
@@ -106,6 +106,7 @@ According to the described logic, the following validation errors are defined:
 * *Tag not allowed*: A tag is found that is not allowed by a condition
 * *Enum value not allowed*: A tag has a value that is not one of the allowed enum values for this tag
 * *Invalid value*: The tag value fails the VR validation as performed by ``pydicom``
+* *Invalid sequence*: A sequence tag has an incorrect VR and is ignored in the validation
 
 Condition parsing
 .................


### PR DESCRIPTION
- used to raise a RuntimeError instead
- fixes #288 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] For documentation changes: docs build succeeded and documentation looks as expected
- [x] Unit tests passing
