### PR TITLE
Split error formatting (tags to text) from error reporting (logging, html, etc.)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 The released versions correspond to PyPi releases.
 `dicom-validator` versions follow [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changes
+* method to handle error message formatting added to `ValidationResultHandlerBase` 
+  and used by `LoggingResultHandler` and `HtmlErrorHandler` (see
+  [#291](https://github.com/pydicom/dicom-validator/issues/291))
+
 ## [Version 0.8.3](https://pypi.python.org/pypi/dicom-validator/0.8.3) (2026-08-28)
 Changed invalid sequence handling.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,17 @@ The released versions correspond to PyPi releases.
 ## Unreleased
 
 ### Changes
-* method to handle error message formatting added to `ValidationResultHandlerBase` 
-  and used by `LoggingResultHandler` and `HtmlErrorHandler` (see
-  [#291](https://github.com/pydicom/dicom-validator/issues/291))
+* tag error and failed-validation message formatting is now shared via a new
+  `ValidationResultFormatter` class, used by both `LoggingResultHandler` and
+  `HtmlErrorHandler` (see [#291](https://github.com/pydicom/dicom-validator/issues/291))
+* added `NullValidationResultHandler`, a no-op handler as already seen in the API
+  documentation, provided as a small convenience.
+
+### Fixes
+* `HtmlErrorHandler`  now reports why validation cannot be started, matching `LoggingResultHandler`
+* `HtmlErrorHandler` tag error messages now include the same detail as
+  `LoggingResultHandler` for enum values and invalid sequences, and tag names
+  are now ordered consistently with `LoggingResultHandler`'s output
 
 ## [Version 0.8.3](https://pypi.python.org/pypi/dicom-validator/0.8.3) (2026-08-28)
 Changed invalid sequence handling.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ The released versions correspond to PyPi releases.
   `HtmlErrorHandler` (see [#291](https://github.com/pydicom/dicom-validator/issues/291))
 * added `NullValidationResultHandler`, a no-op handler as already seen in the API
   documentation, provided as a small convenience.
+* `LoggingResultHandler` and `HtmlErrorHandler` now expose the
+  `ValidationResultFormatter` they use as a public `formatter` attribute, so a
+  subclass can reuse the default rendering (e.g. `self.formatter.error_message(...)`)
+  without constructing its own separate formatter.
 
 ### Fixes
 * `HtmlErrorHandler`  now reports why validation cannot be started, matching `LoggingResultHandler`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
+### Breaking changes
+* `LoggingResultHandler.error_message` and `HtmlErrorHandler.error_message`/`tag_name`
+  have been removed. Use `ValidationResultFormatter.error_message` and
+  `dicom_validator.tag_tools.tag_name_from_id` directly instead
+  (see [#291](https://github.com/pydicom/dicom-validator/issues/291))
+* `ValidationResult.module_errors` is no longer `Optional` - it is always a
+  (possibly empty) dict, never `None`
+
 ### Changes
 * tag error and failed-validation message formatting is now shared via a new
   `ValidationResultFormatter` class, used by both `LoggingResultHandler` and
@@ -14,8 +22,9 @@ The released versions correspond to PyPi releases.
 ### Fixes
 * `HtmlErrorHandler`  now reports why validation cannot be started, matching `LoggingResultHandler`
 * `HtmlErrorHandler` tag error messages now include the same detail as
-  `LoggingResultHandler` for enum values and invalid sequences, and tag names
-  are now ordered consistently with `LoggingResultHandler`'s output
+  `LoggingResultHandler`, including condition text, enum values, and invalid
+  sequences, and tag names are now ordered consistently with
+  `LoggingResultHandler`'s output
 
 ## [Version 0.8.3](https://pypi.python.org/pypi/dicom-validator/0.8.3) (2026-08-28)
 Changed invalid sequence handling.

--- a/dicom_validator/tests/validator/test_dicom_file_validator.py
+++ b/dicom_validator/tests/validator/test_dicom_file_validator.py
@@ -101,7 +101,6 @@ def test_that_pixeldata_is_read(dicom_fixture_path, validator: DicomFileValidato
     result_dict = validator.validate(rtdose_path)
     assert len(result_dict) == 1
     result = result_dict[str(rtdose_path)]
-    assert result.module_errors is not None
     assert "RT Series" in result.module_errors
     oper_name_error = result.module_errors["RT Series"].get(DicomTag(0x0008_1070))
     assert oper_name_error is not None

--- a/dicom_validator/tests/validator/test_error_handler.py
+++ b/dicom_validator/tests/validator/test_error_handler.py
@@ -1,14 +1,21 @@
+import logging
 from pathlib import Path
 
 import pytest
-from pydicom import uid
+from pydicom import DataElement, uid
 
+from dicom_validator.tests.utils import has_tag_error
 from dicom_validator.validator.dicom_file_validator import DicomFileValidator
 from dicom_validator.validator.error_handler import (
+    NullValidationResultHandler,
+    ValidationResultFormatter,
     ValidationResultHandler,
 )
 from dicom_validator.validator.html_error_handler import HtmlErrorHandler
 from dicom_validator.validator.validation_result import (
+    DicomTag,
+    ErrorCode,
+    Status,
     ValidationResult,
 )
 
@@ -60,3 +67,143 @@ def test_html_error_handler(dicom_info, dicom_fixture_path) -> None:
         '<h3><a href="https://dicom.nema.org/medical/dicom/current/output/chtml/part03'
         '/sect_C.8.8.html">RT Series</a></h3>' in handler.html
     )
+
+
+def test_html_error_handler_failed_validation(dicom_info, validator) -> None:
+    """Check that a failed validation is reported."""
+    handler = HtmlErrorHandler(dicom_info)
+    validator.handler = handler
+    validator.validate()
+    assert "<p>Missing SOP Class UID</p>" in handler.html
+
+
+@pytest.mark.tag_set(
+    {
+        "SOPClassUID": uid.CTImageStorage,
+        "DerivationCodeSequence": DataElement(
+            "DerivationCodeSequence", "OB", b"\x00" * 10
+        ),
+    }
+)
+def test_html_error_handler_invalid_sequence(dicom_info, validator) -> None:
+    """Check that an invalid sequence is reported."""
+    handler = HtmlErrorHandler(dicom_info)
+    validator.handler = handler
+    validator.validate()
+    assert (
+        "<li>(0008,9215) (Derivation Code Sequence)"
+        " is not a valid sequence, ignoring it</li>" in handler.html
+    )
+
+
+def test_null_validation_result_handler(validator, caplog) -> None:
+    """Check that validation happens with a null handler, but nothing is logged."""
+    validator.handler = NullValidationResultHandler()
+    with caplog.at_level(logging.DEBUG):
+        result = validator.validate()
+
+    assert result.status == Status.MissingSOPClassUID
+    assert result.errors == 1
+    assert caplog.records == []
+
+
+@pytest.mark.tag_set(
+    {
+        "SOPClassUID": uid.CTImageStorage,
+        "PatientName": "XXX",
+        "PatientID": "ZZZ",
+    }
+)
+def test_null_validation_result_handler_with_module_errors(validator, caplog) -> None:
+    """Check module errors are found with the null handler."""
+    validator.handler = NullValidationResultHandler()
+    with caplog.at_level(logging.DEBUG):
+        result = validator.validate()
+
+    assert has_tag_error(result, "Patient", 0x0010_0040, ErrorCode.TagMissing)
+    assert caplog.records == []
+
+
+@pytest.mark.tag_set(
+    {
+        "SOPClassUID": uid.CTImageStorage,
+        "PatientName": "XXX",
+        "PatientID": "ZZZ",
+        "UltrasoundColorDataPresent": 1,  # triggers TagUnexpected
+    }
+)
+def test_formatter_error_message_tag_unexpected(validator) -> None:
+    """Check unexpected tags are correctly converted to human-readable text."""
+    validator.handler = NullValidationResultHandler()
+    result = validator.validate()
+    tag_error = result.module_errors["General"].get(DicomTag(0x0028_0014))
+    assert tag_error is not None
+
+    formatter = ValidationResultFormatter()
+    assert formatter.error_message(tag_error) == " is unexpected"
+
+
+@pytest.mark.tag_set(
+    {
+        "SOPClassUID": uid.CTImageStorage,
+        "PatientName": "XXX",
+        "PatientID": "ZZZ",
+        "MultienergyCTAcquisition": "YES",
+        "CTAdditionalXRaySourceSequence": [],
+    }
+)
+def test_formatter_error_message_tag_not_allowed(dicom_info, validator) -> None:
+    """Check formatting of text for tags that are not allowed by a condition.
+
+    Based on test_iod_validator.py::test_not_allowed_tag
+    """
+    validator.handler = NullValidationResultHandler()
+    result = validator.validate()
+    tag_error = result.module_errors["CT Image"].get(DicomTag(0x0018_9360))
+    assert tag_error is not None
+
+    # without a dictionary, condition text is left out
+    formatter = ValidationResultFormatter()
+    assert formatter.error_message(tag_error) == " is not allowed"
+
+    # with a dictionary, the condition is rendered too
+    formatter = ValidationResultFormatter(dicom_info.dictionary)
+    assert formatter.error_message(tag_error) == (
+        " is not allowed by condition:\n"
+        '  Multi-energy CT Acquisition is equal to "YES"'
+    )
+
+
+@pytest.mark.parametrize(
+    "result,expected",
+    [
+        (
+            ValidationResult(status=Status.MissingSOPClassUID),
+            "Missing SOP Class UID",
+        ),
+        (
+            ValidationResult(status=Status.UnknownSOPClassUID, sop_class_uid="1.2.3"),
+            "Unknown or retired SOP Class UID: 1.2.3",
+        ),
+        (
+            ValidationResult(status=Status.MissingFile, file_path="foo.dcm"),
+            "Missing DICOM File: foo.dcm",
+        ),
+        (
+            ValidationResult(status=Status.InvalidFile, file_path="foo.dcm"),
+            "Not a DICOM File: foo.dcm - ignoring",
+        ),
+        (ValidationResult(status="UNKNOWN"), "Unknown error"),
+    ],
+    ids=[
+        "missing-sop-class-uid",
+        "unknown-sop-class-uid",
+        "missing-file",
+        "invalid-file",
+        "unknown-status",
+    ],
+)
+def test_formatter_failed_validation_message(result, expected) -> None:
+    """Check that every failed-validation status maps to the correct message."""
+    formatter = ValidationResultFormatter()
+    assert formatter.failed_validation_message(result) == expected

--- a/dicom_validator/tests/validator/test_error_handler.py
+++ b/dicom_validator/tests/validator/test_error_handler.py
@@ -193,14 +193,16 @@ def test_formatter_error_message_tag_not_allowed(dicom_info, validator) -> None:
             ValidationResult(status=Status.InvalidFile, file_path="foo.dcm"),
             "Not a DICOM File: foo.dcm - ignoring",
         ),
-        (ValidationResult(status="UNKNOWN"), "Unknown error"),
+        # Passed is never actually passed to this method, but the default branch should still
+        # behave sensibly if it's ever reached
+        (ValidationResult(status=Status.Passed), "Unknown error"),
     ],
     ids=[
         "missing-sop-class-uid",
         "unknown-sop-class-uid",
         "missing-file",
         "invalid-file",
-        "unknown-status",
+        "unreachable-status-fallback",
     ],
 )
 def test_formatter_failed_validation_message(result, expected) -> None:

--- a/dicom_validator/tests/validator/test_iod_validator_func_groups.py
+++ b/dicom_validator/tests/validator/test_iod_validator_func_groups.py
@@ -110,7 +110,6 @@ class TestIODValidatorFuncGroups:
 
     @staticmethod
     def ensure_group_result(result: ValidationResult) -> TagErrors:
-        assert result.module_errors is not None
         assert "Multi-frame Functional Groups" in result.module_errors
         return result.module_errors["Multi-frame Functional Groups"]
 

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -119,6 +119,68 @@ class ValidationResultHandlerBase(ValidationResultHandler):
         Called to handle parent sequence tags. Is called once
         after one or more tag errors with the same parent sequences appeared."""
 
+    def _error_message(
+        self, error: TagError, dictionary: dict, indent: int = 0
+    ) -> str:
+        """Return a human-readable message fragment for a tag error.
+
+        Parameters
+        ----------
+        error : TagError
+            The error to be rendered.
+        dictionary : dict
+            The DICOM dictionary (`DicomInfo.dictionary`), used to look up
+            condition text for `ErrorCode.TagNotAllowed` errors.
+        indent : int
+            Current indentation level, in case the message itself needs to
+            be indented further (e.g. for a condition on multiple lines).
+            Defaults to 0.
+
+        Returns
+        -------
+        str
+            A message fragment starting with a space, to be appended after
+            the tag name.
+        """
+        match error.scope:
+            case ErrorScope.SharedFuncGroup:
+                postfix = " in Shared Group"
+            case ErrorScope.PerFrameFuncGroup:
+                postfix = " in Per-Frame Group"
+            case ErrorScope.BothFuncGroups:
+                postfix = " in both Shared and Per-Frame Groups"
+            case _:
+                postfix = ""
+
+        match error.code:
+            case ErrorCode.TagMissing:
+                return f" is missing{postfix}"
+            case ErrorCode.TagEmpty:
+                return " is empty"
+            case ErrorCode.TagUnexpected:
+                return f" is unexpected{postfix}"
+            case ErrorCode.TagNotAllowed:
+                msg = f" is not allowed{postfix}"
+                if error.context and "cond" in error.context:
+                    indent += 1
+                    condition = Condition.read_condition(error.context["cond"])
+                    if condition.type != ConditionType.UserDefined:
+                        msg += f" by condition:\n{'  ' * indent}{condition.to_string(dictionary)}"
+                return msg
+            case ErrorCode.EnumValueNotAllowed:
+                error.context = error.context or {}
+                return (
+                    f" - enum value '{error.context.get('value', '')}' not allowed,\n"
+                    f"  allowed values: {', '.join([str(v) for v in error.context.get('allowed', [])])}"
+                )
+            case ErrorCode.InvalidValue:
+                error.context = error.context or {}
+                return f" has invalid value '{error.context['value']}' for VR {error.context['VR'] if error.context else ''}"
+            case ErrorCode.InvalidSequence:
+                return " is not a valid sequence, ignoring it"
+            case _:
+                return ""
+
 
 class LoggingResultHandler(ValidationResultHandlerBase):
     """Handles the result of the validation of a single DICOM file
@@ -185,44 +247,27 @@ class LoggingResultHandler(ValidationResultHandlerBase):
         self.logger.error(msg)
 
     def error_message(self, error: TagError, indent: int) -> str:
-        match error.scope:
-            case ErrorScope.SharedFuncGroup:
-                postfix = " in Shared Group"
-            case ErrorScope.PerFrameFuncGroup:
-                postfix = " in Per-Frame Group"
-            case ErrorScope.BothFuncGroups:
-                postfix = " in both Shared and Per-Frame Groups"
-            case _:
-                postfix = ""
+        """Return a human-readable message fragment for a tag error.
 
-        match error.code:
-            case ErrorCode.TagMissing:
-                return f" is missing{postfix}"
-            case ErrorCode.TagEmpty:
-                return " is empty"
-            case ErrorCode.TagUnexpected:
-                return f" is unexpected{postfix}"
-            case ErrorCode.TagNotAllowed:
-                msg = f" is not allowed{postfix}"
-                if error.context and "cond" in error.context:
-                    indent += 1
-                    condition = Condition.read_condition(error.context["cond"])
-                    if condition.type != ConditionType.UserDefined:
-                        msg += f" by condition:\n{'  ' * indent}{condition.to_string(self.dicom_info.dictionary)}"
-                return msg
-            case ErrorCode.EnumValueNotAllowed:
-                error.context = error.context or {}
-                return (
-                    f" - enum value '{error.context.get('value', '')}' not allowed,\n"
-                    f"  allowed values: {', '.join([str(v) for v in error.context.get('allowed', [])])}"
-                )
-            case ErrorCode.InvalidValue:
-                error.context = error.context or {}
-                return f" has invalid value '{error.context['value']}' for VR {error.context['VR'] if error.context else ''}"
-            case ErrorCode.InvalidSequence:
-                return " is not a valid sequence, ignoring it"
-            case _:
-                return ""
+        Parameters
+        ----------
+        error : TagError
+            The error to be rendered.
+        indent : int
+            Current indentation level, in case the message itself needs to
+            be indented further (e.g. for a condition on multiple lines).
+
+        Returns
+        -------
+        str
+            A message fragment starting with a space, to be appended after
+            the tag name.
+        """
+        return self._error_message(
+            error=error,
+            dictionary=self.dicom_info.dictionary,
+            indent=indent,
+        )
 
 
 def default_error_handler(dicom_info: DicomInfo, log_level: int = logging.INFO):

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -36,6 +36,20 @@ class ValidationResultHandler(Protocol):
         ...
 
 
+class NullValidationResultHandler(ValidationResultHandler):
+    """A no-op handler.
+
+    Useful when you only want to read the `ValidationResult` after `validate()`
+    returns, without any additional reporting.
+    """
+
+    def handle_validation_start(self, result: ValidationResult) -> None:
+        ...  # no-op: this handler intentionally does no reporting
+
+    def handle_validation_result(self, result: ValidationResult) -> None:
+        ...  # no-op: this handler intentionally does no reporting
+
+
 class ValidationResultHandlerBase(ValidationResultHandler):
     """Provides a skeleton implementation for a result handler.
     An easy way to implement another handler is to derive from this class

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -119,18 +119,28 @@ class ValidationResultHandlerBase(ValidationResultHandler):
         Called to handle parent sequence tags. Is called once
         after one or more tag errors with the same parent sequences appeared."""
 
-    def _error_message(
-        self, error: TagError, dictionary: dict, indent: int = 0
-    ) -> str:
+
+class ValidationResultFormatter:
+    """Renders `TagError` and `ValidationResult` objects as human-readable text."""
+
+    def __init__(self, dictionary: dict | None = None) -> None:
+        """Initialise the formatter.
+
+        Parameters
+        ----------
+        dictionary : dict, optional
+            The DICOM dictionary (`DicomInfo.dictionary`), used to look up
+            condition text for `ErrorCode.TagNotAllowed` errors.
+        """
+        self.dictionary = dictionary
+
+    def error_message(self, error: TagError, indent: int = 0) -> str:
         """Return a human-readable message fragment for a tag error.
 
         Parameters
         ----------
         error : TagError
             The error to be rendered.
-        dictionary : dict
-            The DICOM dictionary (`DicomInfo.dictionary`), used to look up
-            condition text for `ErrorCode.TagNotAllowed` errors.
         indent : int
             Current indentation level, in case the message itself needs to
             be indented further (e.g. for a condition on multiple lines).
@@ -161,11 +171,11 @@ class ValidationResultHandlerBase(ValidationResultHandler):
                 return f" is unexpected{postfix}"
             case ErrorCode.TagNotAllowed:
                 msg = f" is not allowed{postfix}"
-                if error.context and "cond" in error.context:
+                if self.dictionary and error.context and "cond" in error.context:
                     indent += 1
                     condition = Condition.read_condition(error.context["cond"])
                     if condition.type != ConditionType.UserDefined:
-                        msg += f" by condition:\n{'  ' * indent}{condition.to_string(dictionary)}"
+                        msg += f" by condition:\n{'  ' * indent}{condition.to_string(self.dictionary)}"
                 return msg
             case ErrorCode.EnumValueNotAllowed:
                 error.context = error.context or {}
@@ -181,6 +191,32 @@ class ValidationResultHandlerBase(ValidationResultHandler):
             case _:
                 return ""
 
+    def failed_validation_message(self, result: ValidationResult) -> str:
+        """Return a human-readable message for a result that could not be validated.
+
+        Parameters
+        ----------
+        result : ValidationResult
+            The result of a validation that failed to start (`result.status`
+            is not `Status.Passed` or `Status.Failed`).
+
+        Returns
+        -------
+        str
+            A message describing why the validation could not be started.
+        """
+        match result.status:
+            case Status.MissingSOPClassUID:
+                return "Missing SOP Class UID"
+            case Status.UnknownSOPClassUID:
+                return f"Unknown or retired SOP Class UID: {result.sop_class_uid}"
+            case Status.MissingFile:
+                return f"Missing DICOM File: {result.file_path}"
+            case Status.InvalidFile:
+                return f"Not a DICOM File: {result.file_path} - ignoring"
+            case _:
+                return "Unknown error"
+
 
 class LoggingResultHandler(ValidationResultHandlerBase):
     """Handles the result of the validation of a single DICOM file
@@ -190,6 +226,7 @@ class LoggingResultHandler(ValidationResultHandlerBase):
     def __init__(self, dicom_info: DicomInfo, logger: logging.Logger) -> None:
         self.dicom_info = dicom_info
         self.logger = logger
+        self._formatter = ValidationResultFormatter(dicom_info.dictionary)
 
     def handle_validation_start(self, result: ValidationResult) -> None:
         iod_info = self.dicom_info.iods[result.sop_class_uid]
@@ -233,18 +270,7 @@ class LoggingResultHandler(ValidationResultHandlerBase):
             self.logger.info("\n")
 
     def handle_failed_validation_start(self, result: ValidationResult) -> None:
-        match result.status:
-            case Status.MissingSOPClassUID:
-                msg = "Missing SOP Class UID"
-            case Status.UnknownSOPClassUID:
-                msg = f"Unknown or retired SOP Class UID: {result.sop_class_uid}"
-            case Status.MissingFile:
-                msg = f"Missing DICOM File: {result.file_path}"
-            case Status.InvalidFile:
-                msg = f"Not a DICOM File: {result.file_path} - ignoring"
-            case _:
-                msg = "Unknown error"
-        self.logger.error(msg)
+        self.logger.error(self._formatter.failed_validation_message(result))
 
     def error_message(self, error: TagError, indent: int) -> str:
         """Return a human-readable message fragment for a tag error.
@@ -263,11 +289,7 @@ class LoggingResultHandler(ValidationResultHandlerBase):
             A message fragment starting with a space, to be appended after
             the tag name.
         """
-        return self._error_message(
-            error=error,
-            dictionary=self.dicom_info.dictionary,
-            indent=indent,
-        )
+        return self._formatter.error_message(error, indent)
 
 
 def default_error_handler(dicom_info: DicomInfo, log_level: int = logging.INFO):

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -43,11 +43,13 @@ class NullValidationResultHandler(ValidationResultHandler):
     returns, without any additional reporting.
     """
 
-    def handle_validation_start(self, result: ValidationResult) -> None:
-        ...  # no-op: this handler intentionally does no reporting
+    def handle_validation_start(
+        self, result: ValidationResult
+    ) -> None: ...  # no-op: this handler intentionally does no reporting
 
-    def handle_validation_result(self, result: ValidationResult) -> None:
-        ...  # no-op: this handler intentionally does no reporting
+    def handle_validation_result(
+        self, result: ValidationResult
+    ) -> None: ...  # no-op: this handler intentionally does no reporting
 
 
 class ValidationResultHandlerBase(ValidationResultHandler):

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -242,7 +242,7 @@ class LoggingResultHandler(ValidationResultHandlerBase):
     def __init__(self, dicom_info: DicomInfo, logger: logging.Logger) -> None:
         self.dicom_info = dicom_info
         self.logger = logger
-        self._formatter = ValidationResultFormatter(dicom_info.dictionary)
+        self.formatter = ValidationResultFormatter(dicom_info.dictionary)
 
     def handle_validation_start(self, result: ValidationResult) -> None:
         iod_info = self.dicom_info.iods[result.sop_class_uid]
@@ -270,7 +270,7 @@ class LoggingResultHandler(ValidationResultHandlerBase):
     def handle_tag_error(self, tag_id: DicomTag, error: TagError) -> None:
         indent = 1 if tag_id.parents else 0
         tag_name = tag_name_from_id(tag_id.tag, self.dicom_info.dictionary)
-        message = self._formatter.error_message(error, indent)
+        message = self.formatter.error_message(error, indent)
         self.logger.warning(f"{'  ' * indent}Tag {tag_name}{message}")
 
     def handle_validation_result_start(
@@ -286,7 +286,7 @@ class LoggingResultHandler(ValidationResultHandlerBase):
             self.logger.info("\n")
 
     def handle_failed_validation_start(self, result: ValidationResult) -> None:
-        self.logger.error(self._formatter.failed_validation_message(result))
+        self.logger.error(self.formatter.failed_validation_message(result))
 
 
 def default_error_handler(dicom_info: DicomInfo, log_level: int = logging.INFO):

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -140,7 +140,7 @@ class ValidationResultFormatter:
     """Renders `TagError` and `ValidationResult` objects as human-readable text."""
 
     def __init__(self, dictionary: dict | None = None) -> None:
-        """Initialise the formatter.
+        """Initialize the formatter.
 
         Parameters
         ----------

--- a/dicom_validator/validator/error_handler.py
+++ b/dicom_validator/validator/error_handler.py
@@ -270,8 +270,8 @@ class LoggingResultHandler(ValidationResultHandlerBase):
     def handle_tag_error(self, tag_id: DicomTag, error: TagError) -> None:
         indent = 1 if tag_id.parents else 0
         tag_name = tag_name_from_id(tag_id.tag, self.dicom_info.dictionary)
-        msg = f"{'  ' * indent}Tag {tag_name}{self.error_message(error, indent)}"
-        self.logger.warning(msg)
+        message = self._formatter.error_message(error, indent)
+        self.logger.warning(f"{'  ' * indent}Tag {tag_name}{message}")
 
     def handle_validation_result_start(
         self, validation_result: ValidationResult
@@ -287,25 +287,6 @@ class LoggingResultHandler(ValidationResultHandlerBase):
 
     def handle_failed_validation_start(self, result: ValidationResult) -> None:
         self.logger.error(self._formatter.failed_validation_message(result))
-
-    def error_message(self, error: TagError, indent: int) -> str:
-        """Return a human-readable message fragment for a tag error.
-
-        Parameters
-        ----------
-        error : TagError
-            The error to be rendered.
-        indent : int
-            Current indentation level, in case the message itself needs to
-            be indented further (e.g. for a condition on multiple lines).
-
-        Returns
-        -------
-        str
-            A message fragment starting with a space, to be appended after
-            the tag name.
-        """
-        return self._formatter.error_message(error, indent)
 
 
 def default_error_handler(dicom_info: DicomInfo, log_level: int = logging.INFO):

--- a/dicom_validator/validator/html_error_handler.py
+++ b/dicom_validator/validator/html_error_handler.py
@@ -7,7 +7,10 @@ from pydicom.tag import BaseTag
 
 from dicom_validator.tag_tools import tag_name_from_id
 from dicom_validator.validator.dicom_info import DicomInfo
-from dicom_validator.validator.error_handler import ValidationResultHandlerBase
+from dicom_validator.validator.error_handler import (
+    ValidationResultFormatter,
+    ValidationResultHandlerBase,
+)
 from dicom_validator.validator.validation_result import (
     DicomTag,
     TagError,
@@ -24,6 +27,7 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
 
     def __init__(self, dicom_info: DicomInfo) -> None:
         self.dicom_info = dicom_info
+        self._formatter = ValidationResultFormatter(dicom_info.dictionary)
         self.html = ""
         self.sop_class = ""
 
@@ -36,6 +40,11 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
     def handle_validation_result_end(self, result: ValidationResult) -> None:
         """Finalize the HTML output for a validation result."""
         self.html = f"<html><body>{self.html}</body></html>"
+
+    def handle_failed_validation_start(self, result: ValidationResult) -> None:
+        """Add a paragraph explaining why the validation could not be started."""
+        message = self._formatter.failed_validation_message(result)
+        self.html += f"<p>{html.escape(message)}</p>"
 
     @staticmethod
     def url_for_ref(ref) -> str:
@@ -111,7 +120,8 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
         """Close the HTML list for the current module's errors."""
         self.html += "</ul>\n"
 
-    def error_message(self, error: TagError) -> str:
+    @staticmethod
+    def error_message(error: TagError) -> str:
         """Return a human-readable message fragment for a tag error.
 
         Parameters
@@ -124,10 +134,7 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
         str
             A short message starting with a space to append after the tag name.
         """
-        message = self._error_message(
-            error=error,
-            dictionary=self.dicom_info.dictionary,
-        )
+        message = ValidationResultFormatter().error_message(error)
         return html.escape(message).replace("\n", "<br>")
 
     def tag_name(self, tag_id: BaseTag) -> str:
@@ -141,13 +148,10 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
         Returns
         -------
         str
-            A string like 'Patient Name (0010,0010)' when known, otherwise the
-            tag ID string.
+            A string like '(0010,0010) (Patient's Name)' when known, otherwise
+            the tag ID string.
         """
-        dict_info = self.dicom_info.dictionary
-        if str(tag_id) in dict_info:
-            return f'{dict_info[str(tag_id)]["name"]} {tag_id}'
-        return str(tag_id)
+        return tag_name_from_id(tag_id, self.dicom_info.dictionary)
 
     def handle_tag_error(self, tag_id: DicomTag, error: TagError) -> None:
         """Append a single tag error as an HTML list item."""

--- a/dicom_validator/validator/html_error_handler.py
+++ b/dicom_validator/validator/html_error_handler.py
@@ -1,3 +1,4 @@
+import html
 from http.client import CannotSendHeader, HTTPSConnection
 from typing import ClassVar
 from urllib.parse import urlparse
@@ -9,8 +10,6 @@ from dicom_validator.validator.dicom_info import DicomInfo
 from dicom_validator.validator.error_handler import ValidationResultHandlerBase
 from dicom_validator.validator.validation_result import (
     DicomTag,
-    ErrorCode,
-    ErrorScope,
     TagError,
     TagErrors,
     ValidationResult,
@@ -112,8 +111,7 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
         """Close the HTML list for the current module's errors."""
         self.html += "</ul>\n"
 
-    @staticmethod
-    def error_message(error: TagError) -> str:
+    def error_message(self, error: TagError) -> str:
         """Return a human-readable message fragment for a tag error.
 
         Parameters
@@ -126,39 +124,11 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
         str
             A short message starting with a space to append after the tag name.
         """
-        match error.scope:
-            case ErrorScope.SharedFuncGroup:
-                postfix = " in Shared Group"
-            case ErrorScope.PerFrameFuncGroup:
-                postfix = " in Per-Frame Group"
-            case ErrorScope.BothFuncGroups:
-                postfix = " in both Shared and Per-Frame Groups"
-            case _:
-                postfix = ""
-
-        match error.code:
-            case ErrorCode.TagMissing:
-                return f" is missing{postfix}"
-            case ErrorCode.TagEmpty:
-                return " is empty"
-            case ErrorCode.TagUnexpected:
-                return f" is unexpected{postfix}"
-            case ErrorCode.TagNotAllowed:
-                return f" is not allowed{postfix}"
-            case ErrorCode.EnumValueNotAllowed:
-                error.context = error.context or {}
-                return f" - enum value '{error.context.get('value', '')}' not allowed"
-            case ErrorCode.InvalidValue:
-                info = ""
-                if error.context is not None:
-                    value = error.context.get("value", "")
-                    vr = error.context.get("VR", "")
-                    info = f" '{value}' for VR {vr}"
-                return f" has invalid value{info}"
-            case ErrorCode.InvalidSequence:
-                return " is not a valid sequence"
-            case _:
-                return ""
+        message = self._error_message(
+            error=error,
+            dictionary=self.dicom_info.dictionary,
+        )
+        return html.escape(message).replace("\n", "<br>")
 
     def tag_name(self, tag_id: BaseTag) -> str:
         """Return a human-readable name for a tag, including its ID.

--- a/dicom_validator/validator/html_error_handler.py
+++ b/dicom_validator/validator/html_error_handler.py
@@ -120,44 +120,13 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
         """Close the HTML list for the current module's errors."""
         self.html += "</ul>\n"
 
-    @staticmethod
-    def error_message(error: TagError) -> str:
-        """Return a human-readable message fragment for a tag error.
-
-        Parameters
-        ----------
-        error : TagError
-            The error to be rendered.
-
-        Returns
-        -------
-        str
-            A short message starting with a space to append after the tag name.
-        """
-        message = ValidationResultFormatter().error_message(error)
-        return html.escape(message).replace("\n", "<br>")
-
-    def tag_name(self, tag_id: BaseTag) -> str:
-        """Return a human-readable name for a tag, including its ID.
-
-        Parameters
-        ----------
-        tag_id : BaseTag
-            DICOM tag identifier.
-
-        Returns
-        -------
-        str
-            A string like '(0010,0010) (Patient's Name)' when known, otherwise
-            the tag ID string.
-        """
-        return tag_name_from_id(tag_id, self.dicom_info.dictionary)
-
     def handle_tag_error(self, tag_id: DicomTag, error: TagError) -> None:
         """Append a single tag error as an HTML list item."""
-        self.html += (
-            f"<li>{self.tag_name(tag_id.tag)}{self.error_message(error)}</li>\n"
+        tag_name = tag_name_from_id(tag_id.tag, self.dicom_info.dictionary)
+        message = html.escape(self._formatter.error_message(error)).replace(
+            "\n", "<br>"
         )
+        self.html += f"<li>{tag_name}{message}</li>\n"
 
     def handle_tag_parents_start(self, parents: list[BaseTag]) -> None:
         """Start a new section header listing parent sequence tags."""

--- a/dicom_validator/validator/html_error_handler.py
+++ b/dicom_validator/validator/html_error_handler.py
@@ -27,7 +27,7 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
 
     def __init__(self, dicom_info: DicomInfo) -> None:
         self.dicom_info = dicom_info
-        self._formatter = ValidationResultFormatter(dicom_info.dictionary)
+        self.formatter = ValidationResultFormatter(dicom_info.dictionary)
         self.html = ""
         self.sop_class = ""
 
@@ -43,7 +43,7 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
 
     def handle_failed_validation_start(self, result: ValidationResult) -> None:
         """Add a paragraph explaining why the validation could not be started."""
-        message = self._formatter.failed_validation_message(result)
+        message = self.formatter.failed_validation_message(result)
         self.html += f"<p>{html.escape(message)}</p>"
 
     @staticmethod
@@ -123,9 +123,7 @@ class HtmlErrorHandler(ValidationResultHandlerBase):
     def handle_tag_error(self, tag_id: DicomTag, error: TagError) -> None:
         """Append a single tag error as an HTML list item."""
         tag_name = tag_name_from_id(tag_id.tag, self.dicom_info.dictionary)
-        message = html.escape(self._formatter.error_message(error)).replace(
-            "\n", "<br>"
-        )
+        message = html.escape(self.formatter.error_message(error)).replace("\n", "<br>")
         self.html += f"<li>{tag_name}{message}</li>\n"
 
     def handle_tag_parents_start(self, parents: list[BaseTag]) -> None:

--- a/dicom_validator/validator/validation_result.py
+++ b/dicom_validator/validator/validation_result.py
@@ -1,5 +1,5 @@
 import enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pydicom.tag import BaseTag
 
@@ -168,7 +168,7 @@ class ValidationResult:
     file_path: str = ""
     status: Status = Status.Passed
     errors: int = 0
-    module_errors: ModuleErrors | None = None
+    module_errors: ModuleErrors = field(default_factory=ModuleErrors)
 
     def reset(self):
         self.status = Status.Passed
@@ -176,7 +176,6 @@ class ValidationResult:
         self.module_errors = ModuleErrors()
 
     def add_tag_errors(self, module_name: str, tag_errors: TagErrors) -> None:
-        self.module_errors = self.module_errors or ModuleErrors()
         nr_module_errors = len(self.module_errors.get(module_name, []))
         self.module_errors.setdefault(module_name, {}).update(tag_errors)
         self.errors += len(tag_errors) - nr_module_errors

--- a/doc/source/api_usage.rst
+++ b/doc/source/api_usage.rst
@@ -80,8 +80,11 @@ This is done with the assumption that validating a single dataset is fast, and t
 to handle each error directly as it appears (if this assumption turns out not to hold, this
 behavior may change in the future).
 
-Note that the error handling API is very simple. If you do not want to do any handling, you
-can write a null handler:
+Note that the error handling API is very simple.
+
+A null handler
+~~~~~~~~~~~~~~
+If you do not want to do any handling, you can write a null handler:
 
 .. code:: python
 
@@ -104,6 +107,24 @@ And use this for your validation:
     result = validator.validate()
     # handle result yourself
 
+Formatting results and errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you want to render `TagError` or `ValidationResult` objects as human-readable text
+without writing your own formatting, you can use
+:class:`~dicom_validator.validator.error_handler.ValidationResultFormatter` directly - it
+does not require a handler at all:
+
+.. code:: python
+
+    from dicom_validator.validator.error_handler import ValidationResultFormatter
+
+    formatter = ValidationResultFormatter(dicom_info.dictionary)
+    for module_name, tag_errors in (result.module_errors or {}).items():
+        for tag_id, error in tag_errors.items():
+            print(f"{module_name}: {tag_id}{formatter.error_message(error)}")
+
+Custom handlers
+~~~~~~~~~~~~~~~
 You could also move your result handling into `handle_validation_result`.
 The more useful option is to base your handler on
 :class:`~dicom_validator.validator.error_handler.ValidationResultHandlerBase`. This already provides

--- a/doc/source/api_usage.rst
+++ b/doc/source/api_usage.rst
@@ -105,14 +105,19 @@ And use this for your validation:
 
     validator = IODValidator(ds, dicom_info, error_handler=NullValidationResultHandler())
     result = validator.validate()
-    # handle result yourself
+    # handle the result yourself
+
+For convenience, a null handler is implemented in
+:class:`~dicom_validator.validator.error_handler.NullValidationResultHandler`.
 
 Formatting results and errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you want to render `TagError` or `ValidationResult` objects as human-readable text
 without writing your own formatting, you can use
-:class:`~dicom_validator.validator.error_handler.ValidationResultFormatter` directly - it
-does not require a handler at all:
+:class:`~dicom_validator.validator.error_handler.ValidationResultFormatter`.
+
+This works well together with a null handler: validate as shown above, then format the `result`
+it returns:
 
 .. code:: python
 

--- a/doc/source/api_usage.rst
+++ b/doc/source/api_usage.rst
@@ -84,31 +84,17 @@ Note that the error handling API is very simple.
 
 A null handler
 ~~~~~~~~~~~~~~
-If you do not want to do any handling, you can write a null handler:
+If you do not want to do any handling, you can use
+:class:`~dicom_validator.validator.error_handler.NullValidationResultHandler`, a
+handler that does no reporting:
 
 .. code:: python
 
-    from dicom_validator.validator.error_handler import ValidationResultHandler
-
-    class NullValidationResultHandler(ValidationResultHandler):
-        """Handler that does nothing."""
-
-        def handle_validation_start(self, result: ValidationResult):
-            pass
-
-        def handle_validation_result(self, result: ValidationResult):
-            pass
-
-And use this for your validation:
-
-.. code:: python
+    from dicom_validator.validator.error_handler import NullValidationResultHandler
 
     validator = IODValidator(ds, dicom_info, error_handler=NullValidationResultHandler())
     result = validator.validate()
     # handle the result yourself
-
-For convenience, a null handler is implemented in
-:class:`~dicom_validator.validator.error_handler.NullValidationResultHandler`.
 
 Formatting results and errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -124,7 +110,7 @@ it returns:
     from dicom_validator.validator.error_handler import ValidationResultFormatter
 
     formatter = ValidationResultFormatter(dicom_info.dictionary)
-    for module_name, tag_errors in (result.module_errors or {}).items():
+    for module_name, tag_errors in result.module_errors.items():
         for tag_id, error in tag_errors.items():
             print(f"{module_name}: {tag_id}{formatter.error_message(error)}")
 

--- a/doc/source/validator_api.rst
+++ b/doc/source/validator_api.rst
@@ -35,6 +35,11 @@ Base classes
 .. autoclass:: dicom_validator.validator.error_handler.ValidationResultHandlerBase
     :members:
 
+Null error handler
+~~~~~~~~~~~~~~~~~~
+.. autoclass:: dicom_validator.validator.error_handler.NullValidationResultHandler
+    :members:
+
 Default error handler
 ~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: dicom_validator.validator.error_handler.LoggingResultHandler

--- a/doc/source/validator_api.rst
+++ b/doc/source/validator_api.rst
@@ -44,3 +44,8 @@ Example error handler
 ~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: dicom_validator.validator.html_error_handler.HtmlErrorHandler
     :members:
+
+Error Formatting
+~~~~~~~~~~~~~~~~
+.. autoclass:: dicom_validator.validator.error_handler.ValidationResultFormatter
+    :members:


### PR DESCRIPTION
#### Describe the changes
Closes #291 

- added a new `ValidationResultFormatter` class that is responsible for converting tag errors into a human-readable format. It has `error_message` and `failed_validation_message` methods.
- `LoggingResultHandler.error_message`, `LoggingResultHandler.failed_validation_message`, and `HtmlResultHandler.error_message` are now thin wrappers around the corresponding new methods. I've kept these method only to avoid introducing breaking changes.
- added a `HtmlResultHandler.handle_failed_validation_start` function to report that validation could not be performed
- added a `NullValidationResultHandler` class (same as is currently in the docs) just for convenience for users
- added usage docs for the new formatter class and how to use this with the null handler
- added tests for the new classes and methods

Note, this does change the output of the `HtmlValidationResultHandler` (it's more verbose, e.g. `EnumValueNotAllowed ` now lists the allowed values, same as the `LoggingValidationResultHandler` does.). I assumed these could be treated as fixes or improvements rather than breaking changes?

Happy to break this PR up if there are too many changes here

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] For documentation changes: docs build succeeded and documentation looks as expected
- [x] Unit tests passing
